### PR TITLE
prevent restify slack webhook verifacation next()

### DIFF
--- a/src/restify/__tests__/verifySlackWebhook.spec.js
+++ b/src/restify/__tests__/verifySlackWebhook.spec.js
@@ -31,7 +31,7 @@ it('should correctly response the challenge is an url_verification event', () =>
   expect(response.end).toBeCalledWith(
     'kImeZUaSI0jJLowDasma5WEiffaScgsjnINWDlpapA9fB7uCB36d'
   );
-  expect(next).toBeCalled();
+  expect(next).not.toBeCalled();
 });
 
 it('responds with success to url_verification event in body', () => {
@@ -45,7 +45,7 @@ it('responds with success to url_verification event in body', () => {
   expect(response.end).toBeCalledWith(
     'kImeZUaSI0jJLowDasma5WEiffaScgsjnINWDlpapA9fB7uCB36d'
   );
-  expect(next).toBeCalled();
+  expect(next).not.toBeCalled();
 });
 
 it('should only call next when request is not an url_verification event', () => {

--- a/src/restify/verifySlackWebhook.js
+++ b/src/restify/verifySlackWebhook.js
@@ -5,9 +5,9 @@ const verifySlackWebhook = () => (req, res, next) => {
     res.end(req.params.challenge);
   } else if (body && body.type && body.type === 'url_verification') {
     res.end(req.body.challenge);
+  } else {
+    return next();
   }
-
-  return next();
 };
 
 export default verifySlackWebhook;


### PR DESCRIPTION
`url_verification` events should not go next()