### PR TITLE
use Slack conversations API for DM/private channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lru-cache": "^4.1.1",
     "messaging-api-line": "^0.5.2",
     "messaging-api-messenger": "^0.5.3",
-    "messaging-api-slack": "^0.5.2",
+    "messaging-api-slack": "^0.5.6",
     "messaging-api-telegram": "^0.5.2",
     "micro": "^9.0.0",
     "minimist": "^1.2.0",

--- a/src/bot/SlackConnector.js
+++ b/src/bot/SlackConnector.js
@@ -97,7 +97,10 @@ export default class SlackConnector implements Connector<SlackRequestBody> {
         Array.isArray(session.channel.members) &&
         session.channel.members.indexOf(senderId) < 0)
     ) {
-      session.channel = await this._client.getChannelInfo(channelId);
+      session.channel = await this._client.getConversationInfo(channelId);
+      session.channel.members = await this._client.getAllConversationMembers(
+        channelId
+      );
       session.channel._updatedAt = new Date().toISOString();
     }
 

--- a/src/bot/__tests__/SlackConnector.spec.js
+++ b/src/bot/__tests__/SlackConnector.spec.js
@@ -52,7 +52,8 @@ const botRequest = {
 function setup() {
   const mockSlackOAuthClient = {
     getUserInfo: jest.fn(),
-    getChannelInfo: jest.fn(),
+    getConversationInfo: jest.fn(),
+    getAllConversationMembers: jest.fn(),
     getAllUserList: jest.fn(),
   };
   SlackOAuthClient.connect = jest.fn();
@@ -105,8 +106,11 @@ describe('#updateSession', () => {
     const session = {};
 
     mockSlackOAuthClient.getUserInfo.mockReturnValue(Promise.resolve(user));
-    mockSlackOAuthClient.getChannelInfo.mockReturnValue(
+    mockSlackOAuthClient.getConversationInfo.mockReturnValue(
       Promise.resolve(channel)
+    );
+    mockSlackOAuthClient.getAllConversationMembers.mockReturnValue(
+      Promise.resolve(members)
     );
     mockSlackOAuthClient.getAllUserList.mockReturnValue(
       Promise.resolve(members)
@@ -115,7 +119,12 @@ describe('#updateSession', () => {
     await connector.updateSession(session, request.body);
 
     expect(mockSlackOAuthClient.getUserInfo).toBeCalledWith('U13A00000');
-    expect(mockSlackOAuthClient.getChannelInfo).toBeCalledWith('C6A900000');
+    expect(mockSlackOAuthClient.getConversationInfo).toBeCalledWith(
+      'C6A900000'
+    );
+    expect(mockSlackOAuthClient.getAllConversationMembers).toBeCalledWith(
+      'C6A900000'
+    );
     expect(mockSlackOAuthClient.getAllUserList).toBeCalled();
     expect(session).toEqual({
       user: {
@@ -124,6 +133,7 @@ describe('#updateSession', () => {
       },
       channel: {
         _updatedAt: expect.any(String),
+        members,
         ...channel,
       },
       team: { members, _updatedAt: expect.any(String) },
@@ -138,7 +148,8 @@ describe('#updateSession', () => {
     await connector.updateSession(session, botRequest.body);
 
     expect(mockSlackOAuthClient.getUserInfo).not.toBeCalled();
-    expect(mockSlackOAuthClient.getChannelInfo).not.toBeCalled();
+    expect(mockSlackOAuthClient.getConversationInfo).not.toBeCalled();
+    expect(mockSlackOAuthClient.getAllConversationMembers).not.toBeCalled();
     expect(mockSlackOAuthClient.getAllUserList).not.toBeCalled();
     expect(session).toEqual({});
   });
@@ -168,7 +179,8 @@ describe('#updateSession', () => {
     await connector.updateSession(session, body);
 
     expect(mockSlackOAuthClient.getUserInfo).not.toBeCalled();
-    expect(mockSlackOAuthClient.getChannelInfo).not.toBeCalled();
+    expect(mockSlackOAuthClient.getConversationInfo).not.toBeCalled();
+    expect(mockSlackOAuthClient.getAllConversationMembers).not.toBeCalled();
     expect(mockSlackOAuthClient.getAllUserList).not.toBeCalled();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,6 +436,10 @@ axios-error@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/axios-error/-/axios-error-0.5.2.tgz#60cfa895422ce0537b270a4da80a4e121cceb061"
 
+axios-error@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/axios-error/-/axios-error-0.5.4.tgz#f86af6b09df20366c65748e2f0e0b27cf993f8ba"
+
 axios-mock-adapter@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.9.0.tgz#0e387666fceaf3f91262109a3956f588bc6af2d1"
@@ -3860,12 +3864,12 @@ messaging-api-messenger@^0.5.3:
     lodash.omit "^4.5.0"
     warning "^3.0.0"
 
-messaging-api-slack@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/messaging-api-slack/-/messaging-api-slack-0.5.2.tgz#21a6342aa0cc53956df17fb32d08576c6c4efe96"
+messaging-api-slack@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/messaging-api-slack/-/messaging-api-slack-0.5.6.tgz#ba86381b5fd017e157a2aebf57f9711e531e7e99"
   dependencies:
     axios "^0.17.0"
-    axios-error "^0.5.2"
+    axios-error "^0.5.4"
     invariant "^2.2.2"
     warning "^3.0.0"
 


### PR DESCRIPTION
should fix #8 
`getChannelInfo()` only supports public channel
`getConversationInfo()` supports public channel, private channel and DMs