### PR TITLE
pass in options argument in postMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lru-cache": "^4.1.1",
     "messaging-api-line": "^0.5.7",
     "messaging-api-messenger": "^0.5.9",
-    "messaging-api-slack": "^0.5.7",
+    "messaging-api-slack": "^0.5.10",
     "messaging-api-telegram": "^0.5.4",
     "micro": "^9.0.1",
     "minimist": "^1.2.0",

--- a/src/context/SlackContext.js
+++ b/src/context/SlackContext.js
@@ -44,7 +44,7 @@ export default class SlackContext extends Context implements PlatformContext {
     }
   }
 
-  async postMessage(text: string): Promise<any> {
+  postMessage(text: string, options?: {}): Promise<any> {
     const channelId = this._getChannelIdFromSession();
 
     if (!channelId) {
@@ -52,12 +52,15 @@ export default class SlackContext extends Context implements PlatformContext {
         false,
         'postMessage: should not be called in context without session'
       );
-      return;
+      return Promise.resolve();
     }
 
     this._isHandled = true;
 
-    return this._client.postMessage(channelId, text, { as_user: true });
+    return this._client.postMessage(channelId, text, {
+      as_user: true,
+      ...options,
+    });
   }
 
   /**

--- a/src/context/__tests__/SlackContext.spec.js
+++ b/src/context/__tests__/SlackContext.spec.js
@@ -96,6 +96,17 @@ describe('#postMessage', () => {
     });
   });
 
+  it('should support overwrite options', async () => {
+    const { context, client } = setup();
+
+    await context.postMessage('xxx.com', { attachments: [], as_user: false });
+
+    expect(client.postMessage).toBeCalledWith('C6A9RJJ3F', 'xxx.com', {
+      attachments: [],
+      as_user: false,
+    });
+  });
+
   it('should mark context as handled', async () => {
     const { context } = setup();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,9 +3909,9 @@ messaging-api-messenger@^0.5.9:
     lodash.omit "^4.5.0"
     warning "^3.0.0"
 
-messaging-api-slack@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/messaging-api-slack/-/messaging-api-slack-0.5.7.tgz#e54fd07d946e4a03ba08dacf944adf03d04e1c73"
+messaging-api-slack@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/messaging-api-slack/-/messaging-api-slack-0.5.10.tgz#da4e196b28d59bc55dfcf6b89c36d8eda249b6d7"
   dependencies:
     axios "^0.17.0"
     axios-error "^0.5.4"


### PR DESCRIPTION
#24 
support options in `context.postMessage`

For `options.attachments` field auto parsing, wait https://github.com/Yoctol/messaging-apis/pull/208 and upgrade dependency version.