### PR TITLE
stop passing as_user:true

### DIFF
--- a/src/context/SlackContext.js
+++ b/src/context/SlackContext.js
@@ -58,7 +58,6 @@ export default class SlackContext extends Context implements PlatformContext {
     this._isHandled = true;
 
     return this._client.postMessage(channelId, text, {
-      as_user: true,
       ...options,
     });
   }

--- a/src/context/__tests__/SlackContext.spec.js
+++ b/src/context/__tests__/SlackContext.spec.js
@@ -91,9 +91,7 @@ describe('#postMessage', () => {
 
     await context.postMessage('xxx.com');
 
-    expect(client.postMessage).toBeCalledWith('C6A9RJJ3F', 'xxx.com', {
-      as_user: true,
-    });
+    expect(client.postMessage).toBeCalledWith('C6A9RJJ3F', 'xxx.com', {});
   });
 
   it('should support overwrite options', async () => {
@@ -130,9 +128,7 @@ describe('#postMessage', () => {
 
     await context.postMessage('xxx.com');
 
-    expect(client.postMessage).toBeCalledWith(id, 'xxx.com', {
-      as_user: true,
-    });
+    expect(client.postMessage).toBeCalledWith(id, 'xxx.com', {});
   });
 
   it('should get null channelId and call warning if no session', async () => {


### PR DESCRIPTION
https://api.slack.com/methods/chat.postMessage#authorship
I think it's mistake that we pass this before. This is for bots to post as a human user.