### PR TITLE
mock messaging-api-telegram in TelegramContext tests

### DIFF
--- a/src/context/__tests__/TelegramContext.spec.js
+++ b/src/context/__tests__/TelegramContext.spec.js
@@ -1,5 +1,5 @@
 jest.mock('delay');
-jest.mock('messaging-api-messenger');
+jest.mock('messaging-api-telegram');
 jest.mock('warning');
 
 let TelegramContext;


### PR DESCRIPTION
Or we can remove all of api client mocks in context tests