### PR TITLE
[fixed] bottender : changed sendState to setState in ContextSimulator

### DIFF
--- a/src/test-utils/ContextSimulator.js
+++ b/src/test-utils/ContextSimulator.js
@@ -115,7 +115,7 @@ class ContextSimulator {
 
       isHandled: false,
 
-      sendState: this._mockFn(),
+      setState: this._mockFn(),
       resetState: this._mockFn(),
       sendText: this._mockFn(),
       typing: this._mockFn(),


### PR DESCRIPTION
Hey guys , 

in ContextSimulator.js you have set sendState instead of setState
