### PR TITLE
support Messenger webhook test requests

### DIFF
--- a/src/bot/MessengerConnector.js
+++ b/src/bot/MessengerConnector.js
@@ -24,12 +24,14 @@ import type { Session } from '../session/Session';
 import type { Connector } from './Connector';
 
 type Entry = {
-  ['messaging' | 'standby']: Array<{
+  ['messaging' | 'standby' | 'changes']: Array<{
     sender: Sender,
     recipient: Recipient,
     timestamp: number,
     postback?: Postback,
     message?: Message,
+    field?: String,
+    value?: Object,
   }>,
 };
 
@@ -116,6 +118,12 @@ export default class MessengerConnector
           if (ent.standby) {
             return ((ent.standby[0]: any): MessengerRawEvent);
           }
+
+          // for Webhook Test button request and other page events
+          if (ent.changes) {
+            return ((ent.changes[0]: any): MessengerRawEvent);
+          }
+
           // $FlowExpectedError
           return null;
         })
@@ -155,10 +163,15 @@ export default class MessengerConnector
 
   getUniqueSessionKey(body: MessengerRequestBody): ?string {
     const rawEvent = this._getRawEventsFromRequest(body)[0];
-    if (rawEvent.message && rawEvent.message.is_echo && rawEvent.recipient) {
+    if (
+      rawEvent &&
+      rawEvent.message &&
+      rawEvent.message.is_echo &&
+      rawEvent.recipient
+    ) {
       return rawEvent.recipient.id;
     }
-    if (rawEvent.sender) {
+    if (rawEvent && rawEvent.sender) {
       return rawEvent.sender.id;
     }
     return null;

--- a/src/bot/__tests__/MessengerConnector.spec.js
+++ b/src/bot/__tests__/MessengerConnector.spec.js
@@ -143,6 +143,26 @@ const standbyRequest = {
   },
 };
 
+const webhookTestRequest = {
+  body: {
+    entry: [
+      {
+        changes: [
+          {
+            field: 'messages',
+            value: {
+              page_id: '<PAGE_ID>',
+            },
+          },
+        ],
+        id: '0',
+        time: 1514862760,
+      },
+    ],
+    object: 'page',
+  },
+};
+
 function setup(
   { accessToken, appSecret, mapPageToAccessToken } = {
     accessToken: ACCESS_TOKEN,
@@ -207,6 +227,12 @@ describe('#getUniqueSessionKey', () => {
   it('return null if is not first event or echo event', () => {
     const { connector } = setup();
     const senderId = connector.getUniqueSessionKey({});
+    expect(senderId).toBe(null);
+  });
+
+  it('return null if is webhook test event or other null rawEvent requests', () => {
+    const { connector } = setup();
+    const senderId = connector.getUniqueSessionKey(webhookTestRequest.body);
     expect(senderId).toBe(null);
   });
 });


### PR DESCRIPTION
as well as other null `rawEvent` requests

fix #138