### PR TITLE
Handling error in express middleware

### DIFF
--- a/src/express/createMiddleware.js
+++ b/src/express/createMiddleware.js
@@ -1,6 +1,9 @@
 function createMiddleware(bot) {
   const requestHandler = bot.createRequestHandler();
-  return async (req, res) => {
+
+  const wrapper = fn => (req, res, next) =>
+    fn(req, res).catch(err => next(err));
+  return wrapper(async (req, res) => {
     if (!req.body) {
       throw new Error(
         'createMiddleware(): Missing body parser. Use `body-parser` or other similar package before this middleware.'
@@ -15,7 +18,7 @@ function createMiddleware(bot) {
       res.status(200);
       res.send('');
     }
-  };
+  });
 }
 
 export default createMiddleware;


### PR DESCRIPTION
The express middleware actually doesn't handle the async error, i.e. a Promise rejection

The `createMiddleware` may throw error from the `requestHandler` which converts body to the context.

This PR improve the error catching, and forward to the next downstream to prevent `DEP0018: Unhandled promise rejections` warning