### PR TITLE
support all of fallback methods on ConsoleContext

### DIFF
--- a/examples/console-hello-world/index.js
+++ b/examples/console-hello-world/index.js
@@ -1,6 +1,6 @@
 const { ConsoleBot } = require('bottender');
 
-const bot = new ConsoleBot();
+const bot = new ConsoleBot({ fallbackMethods: true });
 
 bot.onEvent(async context => {
   await context.sendText('Hello World');

--- a/src/bot/ConsoleBot.js
+++ b/src/bot/ConsoleBot.js
@@ -7,8 +7,11 @@ import Bot from './Bot';
 import ConsoleConnector from './ConsoleConnector';
 
 export default class ConsoleBot extends Bot {
-  constructor({ sessionStore }: { sessionStore: SessionStore } = {}) {
-    const connector = new ConsoleConnector();
+  constructor({
+    sessionStore,
+    fallbackMethods,
+  }: { sessionStore: SessionStore, fallbackMethods?: boolean } = {}) {
+    const connector = new ConsoleConnector({ fallbackMethods });
     super({ connector, sessionStore, sync: true });
   }
 

--- a/src/bot/ConsoleConnector.js
+++ b/src/bot/ConsoleConnector.js
@@ -14,17 +14,20 @@ export type ConsoleClient = {
 
 type ConstructorOptions = {|
   client?: ConsoleClient,
+  fallbackMethods?: boolean,
 |};
 
 export default class ConsoleConnector implements Connector<ConsoleRequestBody> {
   _client: ConsoleClient;
+  _fallbackMethods: boolean;
 
-  constructor({ client }: ConstructorOptions = {}) {
+  constructor({ client, fallbackMethods }: ConstructorOptions = {}) {
     this._client = client || {
       sendText: text => {
         process.stdout.write(`Bot > ${text}\n`);
       },
     };
+    this._fallbackMethods = fallbackMethods || false;
   }
 
   get platform(): string {
@@ -75,6 +78,7 @@ export default class ConsoleConnector implements Connector<ConsoleRequestBody> {
       event,
       session,
       initialState,
+      fallbackMethods: this._fallbackMethods,
     });
   }
 }

--- a/src/context/__tests__/ConsoleContext.spec.js
+++ b/src/context/__tests__/ConsoleContext.spec.js
@@ -28,7 +28,8 @@ const userSession = {
     name: 'you',
   },
 };
-const setup = ({ session } = { session: userSession }) => {
+
+const setup = ({ session, fallbackMethods } = { session: userSession }) => {
   const client = {
     sendText: jest.fn(),
   };
@@ -36,6 +37,7 @@ const setup = ({ session } = { session: userSession }) => {
     client,
     event: new ConsoleEvent(rawEvent),
     session,
+    fallbackMethods: fallbackMethods || false,
   });
   return {
     client,
@@ -82,6 +84,24 @@ describe('#sendText', () => {
     const { context } = setup();
 
     await context.sendText('hello');
+
+    expect(context.isHandled).toBe(true);
+  });
+});
+
+describe('method missing', () => {
+  it('should write text to stdout', async () => {
+    const { context, client } = setup({ fallbackMethods: true });
+
+    await context.sendABC('hello', { json: true });
+
+    expect(client.sendText).toBeCalledWith('sendABC: ["hello",{"json":true}]');
+  });
+
+  it('should mark context as handled', async () => {
+    const { context } = setup({ fallbackMethods: true });
+
+    await context.sendABC('hello');
 
     expect(context.isHandled).toBe(true);
   });


### PR DESCRIPTION
With `fallbackMethods: true`, we can test all of methods using `ConsoleBot`:

```js
const bot = new ConsoleBot({ fallbackMethods: true });

bot.onEvent(async context => {
  await context.sendText('Hello World');
  await context.sendImage('https://example.com/vr.jpg');
  await context.sendButtonTemplate('What do you want to do next?', [
    {
      type: 'web_url',
      url: 'https://petersapparel.parseapp.com',
      title: 'Show Website',
    },
    {
      type: 'postback',
      title: 'Start Chatting',
      payload: 'USER_DEFINED_PAYLOAD',
    },
  ]);
});
```

Result:

```
Bot > Hello World
Bot > sendImage: ["https://example.com/vr.jpg"]
Bot > sendButtonTemplate: ["What do you want to do next?",[{"type":"web_url","url":"https://petersapparel.parseapp.com","title":"Show Website"},{"type":"postback","title":"Start Chatting","payload":"USER_DEFINED_PAYLOAD"}]]
```