### PR TITLE
Add option --token to Messenger, LINE, Telegram  and  Viber

### DIFF
--- a/src/cli/providers/line/__tests__/deleteLineMenu.spec.js
+++ b/src/cli/providers/line/__tests__/deleteLineMenu.spec.js
@@ -11,9 +11,12 @@ const inquirer = require('inquirer');
 const { print, error } = require('../../../shared/log');
 const getConfig = require('../../../shared/getConfig');
 
-const setup = force => ({
+const setup = (force, token = undefined) => ({
   argv: {
+    f: force,
     force,
+    t: token,
+    token,
   },
 });
 
@@ -58,7 +61,15 @@ describe('deleteLineMenu', () => {
     expect(deleteLineMenu).toBeDefined();
   });
 
-  it('should exit when accessToken is not found in config file', async () => {
+  it('-t, --token should work', async () => {
+    const ctx = setup(false, '12345');
+
+    await deleteLineMenu(ctx);
+
+    expect(LineClient.connect).toBeCalledWith('12345');
+  });
+
+  it('should exit when accessToken is not found in config file and not pass token option', async () => {
     const ctx = setup(false);
 
     getConfig.mockReturnValueOnce({

--- a/src/cli/providers/line/menu.js
+++ b/src/cli/providers/line/menu.js
@@ -32,7 +32,8 @@ export const help = () => {
 
     ${chalk.dim('Options:')}
 
-      --force       With action del, force delete ${bold('ALL')} LINE rich menus
+      -t, --token   Specify LINE access token.
+      -f, --force   With action del, force delete ${bold('ALL')} LINE rich menus
 
     ${chalk.dim('Examples:')}
 
@@ -56,13 +57,23 @@ export function checkLineMenu() {
   }
 }
 
-export async function getLineMenu() {
+export async function getLineMenu(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'line');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'line');
 
-    invariant(config.accessToken, 'accessToken is not found in config file.');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = LineClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = LineClient.connect(accessToken);
 
     const richMenus = await client.getRichMenuList();
 
@@ -87,19 +98,26 @@ export async function getLineMenu() {
   }
 }
 
-export async function setLineMenus() {
-  try {
-    const { accessToken, richMenus: localRichMenus } = getConfig(
-      'bottender.config.js',
-      'line'
-    );
+export async function setLineMenus(ctx) {
+  const { t, token: _token } = ctx.argv;
 
-    invariant(accessToken, 'accessToken is not found in config file.');
+  let accessToken;
+
+  try {
+    const config = getConfig('bottender.config.js', 'line');
+    const { richMenus: localRichMenus } = config;
+
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      invariant(config.accessToken, 'accessToken is not found in config file');
+
+      accessToken = config.accessToken;
+    }
 
     const client = LineClient.connect(accessToken);
 
     const onlineRichMenus = await client.getRichMenuList();
-
     invariant(
       onlineRichMenus,
       `Failed to get ${bold('LINE rich menu')} response.`
@@ -168,13 +186,23 @@ export async function setLineMenus() {
 }
 
 export async function deleteLineMenu(ctx) {
-  const { force } = ctx.argv;
+  const { f, force: _force, t, token: _token } = ctx.argv;
+  const force = f || _force;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'line');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'line');
 
-    invariant(config.accessToken, 'accessToken is not found in config file.');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = LineClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = LineClient.connect(accessToken);
 
     const richMenus = await client.getRichMenuList();
 
@@ -238,7 +266,7 @@ export default async function main(ctx) {
       checkLineMenu();
       break;
     case 'get':
-      await getLineMenu();
+      await getLineMenu(ctx);
       break;
     case 'set':
       await setLineMenus(ctx);

--- a/src/cli/providers/messenger/__tests__/deleteGetStarted.spec.js
+++ b/src/cli/providers/messenger/__tests__/deleteGetStarted.spec.js
@@ -33,10 +33,35 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deleteGetStarted(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deleteGetStarted(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.deleteGetStarted).toBeCalled();
+  });
+
   it('call deleteGetStarted', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.deleteGetStarted.mockReturnValue(Promise.resolve());
 
-    await deleteGetStarted();
+    await deleteGetStarted(ctx);
 
     expect(_client.deleteGetStarted).toBeCalled();
   });
@@ -44,6 +69,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -53,13 +81,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deleteGetStarted();
+    await deleteGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -78,7 +109,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deleteGetStarted();
+    await deleteGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -86,6 +117,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -93,7 +127,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deleteGetStarted();
+    await deleteGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/deleteGreeting.spec.js
+++ b/src/cli/providers/messenger/__tests__/deleteGreeting.spec.js
@@ -33,10 +33,35 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deleteGreeting(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deleteGreeting(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.deleteGreeting).toBeCalled();
+  });
+
   it('call deleteGreeting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.deleteGreeting.mockReturnValue(Promise.resolve());
 
-    await deleteGreeting();
+    await deleteGreeting(ctx);
 
     expect(_client.deleteGreeting).toBeCalled();
   });
@@ -44,6 +69,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -53,13 +81,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deleteGreeting();
+    await deleteGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -78,7 +109,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deleteGreeting();
+    await deleteGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -86,6 +117,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -93,7 +127,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deleteGreeting();
+    await deleteGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/deleteMessengerProfile.spec.js
+++ b/src/cli/providers/messenger/__tests__/deleteMessengerProfile.spec.js
@@ -39,10 +39,35 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deleteMessengerProfile(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deleteMessengerProfile(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.deleteMessengerProfile).toBeCalled();
+  });
+
   it('call deleteMessengerProfile', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.deleteMessengerProfile.mockReturnValue(Promise.resolve());
 
-    await deleteMessengerProfile();
+    await deleteMessengerProfile(ctx);
 
     expect(_client.deleteMessengerProfile).toBeCalledWith([
       'account_linking_url',
@@ -59,6 +84,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -66,13 +94,16 @@ describe('reject', () => {
     };
     _client.deleteMessengerProfile.mockReturnValue(Promise.reject(error));
 
-    await deleteMessengerProfile();
+    await deleteMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -89,7 +120,7 @@ describe('reject', () => {
     };
     _client.deleteMessengerProfile.mockReturnValue(Promise.reject(error));
 
-    await deleteMessengerProfile();
+    await deleteMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -97,12 +128,15 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
     _client.deleteMessengerProfile.mockReturnValue(Promise.reject(error));
 
-    await deleteMessengerProfile();
+    await deleteMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/deletePersistentMenu.spec.js
+++ b/src/cli/providers/messenger/__tests__/deletePersistentMenu.spec.js
@@ -33,10 +33,35 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deletePersistentMenu(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deletePersistentMenu(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.deletePersistentMenu).toBeCalled();
+  });
+
   it('call deletePersistentMenu', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.deletePersistentMenu.mockReturnValue(Promise.resolve());
 
-    await deletePersistentMenu();
+    await deletePersistentMenu(ctx);
 
     expect(_client.deletePersistentMenu).toBeCalled();
   });
@@ -44,6 +69,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -53,13 +81,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deletePersistentMenu();
+    await deletePersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -78,7 +109,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deletePersistentMenu();
+    await deletePersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -86,6 +117,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -93,7 +127,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await deletePersistentMenu();
+    await deletePersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/deleteWhitelistedDomains.spec.js
+++ b/src/cli/providers/messenger/__tests__/deleteWhitelistedDomains.spec.js
@@ -33,10 +33,35 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deleteWhitelistedDomains(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deleteWhitelistedDomains(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.deleteWhitelistedDomains).toBeCalled();
+  });
+
   it('call deleteWhitelistedDomains', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.deleteWhitelistedDomains.mockReturnValue(Promise.resolve());
 
-    await deleteWhitelistedDomains();
+    await deleteWhitelistedDomains(ctx);
 
     expect(_client.deleteWhitelistedDomains).toBeCalled();
   });
@@ -44,6 +69,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -52,13 +80,16 @@ describe('reject', () => {
     _client.deleteWhitelistedDomains.mockReturnValue(Promise.reject(error));
     process.exit = jest.fn();
 
-    await deleteWhitelistedDomains();
+    await deleteWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -76,7 +107,7 @@ describe('reject', () => {
     _client.deleteWhitelistedDomains.mockReturnValue(Promise.reject(error));
     process.exit = jest.fn();
 
-    await deleteWhitelistedDomains();
+    await deleteWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -84,13 +115,16 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
     _client.deleteWhitelistedDomains.mockReturnValue(Promise.reject(error));
     process.exit = jest.fn();
 
-    await deleteWhitelistedDomains();
+    await deleteWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/getGetStarted.spec.js
+++ b/src/cli/providers/messenger/__tests__/getGetStarted.spec.js
@@ -33,22 +33,51 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await getGetStarted(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await getGetStarted(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.getGetStarted).toBeCalled();
+  });
+
   it('call getGetStarted', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getGetStarted.mockReturnValue(
       Promise.resolve({
         payload: 'get started yo!',
       })
     );
 
-    await getGetStarted();
+    await getGetStarted(ctx);
 
     expect(_client.getGetStarted).toBeCalled();
   });
 
   it('error when no config setting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getGetStarted.mockReturnValue(Promise.resolve(null));
 
-    await getGetStarted();
+    await getGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(_client.getGetStarted).toBeCalled();
@@ -57,6 +86,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -66,13 +98,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getGetStarted();
+    await getGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -91,7 +126,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getGetStarted();
+    await getGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -99,6 +134,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -106,7 +144,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getGetStarted();
+    await getGetStarted(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/getGreeting.spec.js
+++ b/src/cli/providers/messenger/__tests__/getGreeting.spec.js
@@ -33,18 +33,47 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await getGreeting(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await getGreeting(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.getGreeting).toBeCalled();
+  });
+
   it('call getGreeting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getGreeting.mockReturnValue(Promise.resolve([{ text: 'hello' }]));
 
-    await getGreeting();
+    await getGreeting(ctx);
 
     expect(_client.getGreeting).toBeCalled();
   });
 
   it('error when no config setting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getGreeting.mockReturnValue(Promise.resolve([]));
 
-    await getGreeting();
+    await getGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(_client.getGreeting).toBeCalled();
@@ -53,6 +82,10 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     const error = {
       response: {
         status: 400,
@@ -62,13 +95,17 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getGreeting();
+    await getGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     const error = {
       response: {
         status: 400,
@@ -87,7 +124,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getGreeting();
+    await getGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -95,6 +132,10 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     const error = {
       message: 'something wrong happened',
     };
@@ -102,7 +143,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getGreeting();
+    await getGreeting(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/getMessengerProfile.spec.js
+++ b/src/cli/providers/messenger/__tests__/getMessengerProfile.spec.js
@@ -33,10 +33,35 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await getMessengerProfile(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await getMessengerProfile(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.getMessengerProfile).toBeCalled();
+  });
+
   it('call getMessengerProfile', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getMessengerProfile.mockReturnValue(Promise.resolve({}));
 
-    await getMessengerProfile();
+    await getMessengerProfile(ctx);
 
     expect(_client.getMessengerProfile).toBeCalledWith([
       'account_linking_url',
@@ -51,9 +76,13 @@ describe('resolved', () => {
   });
 
   it('error when no config setting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getMessengerProfile.mockReturnValue(Promise.resolve(null));
 
-    await getMessengerProfile();
+    await getMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(_client.getMessengerProfile).toBeCalled();
@@ -62,6 +91,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -71,13 +103,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getMessengerProfile();
+    await getMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -96,7 +131,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getMessengerProfile();
+    await getMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -104,6 +139,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -111,7 +149,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getMessengerProfile();
+    await getMessengerProfile(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/getPersistentMenu.spec.js
+++ b/src/cli/providers/messenger/__tests__/getPersistentMenu.spec.js
@@ -39,7 +39,32 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await getPersistentMenu(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await getPersistentMenu(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.getPersistentMenu).toBeCalled();
+  });
+
   it('call getPersistentMenu', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
     _client.getPersistentMenu.mockReturnValue(
       Promise.resolve([
         {
@@ -55,15 +80,19 @@ describe('resolved', () => {
       ])
     );
 
-    await getPersistentMenu();
+    await getPersistentMenu(ctx);
 
     expect(_client.getPersistentMenu).toBeCalled();
   });
 
   it('error when no config setting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getPersistentMenu.mockReturnValue(Promise.resolve([]));
 
-    await getPersistentMenu();
+    await getPersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(_client.getPersistentMenu).toBeCalled();
@@ -72,6 +101,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -81,13 +113,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getPersistentMenu();
+    await getPersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -106,7 +141,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getPersistentMenu();
+    await getPersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -114,6 +149,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -121,7 +159,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getPersistentMenu();
+    await getPersistentMenu(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/getWhitelistedDomains.spec.js
+++ b/src/cli/providers/messenger/__tests__/getWhitelistedDomains.spec.js
@@ -33,20 +33,49 @@ it('be defined', () => {
 });
 
 describe('resolved', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await getWhitelistedDomains(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await getWhitelistedDomains(ctx);
+
+    expect(MessengerClient.connect).toBeCalledWith('12345');
+    expect(_client.getWhitelistedDomains).toBeCalled();
+  });
+
   it('call getWhitelistedDomains', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getWhitelistedDomains.mockReturnValue(
       Promise.resolve(['http://www.facebook.com', 'http://www.yoctol.com'])
     );
 
-    await getWhitelistedDomains();
+    await getWhitelistedDomains(ctx);
 
     expect(_client.getWhitelistedDomains).toBeCalled();
   });
 
   it('error when no config setting', async () => {
+    const ctx = {
+      argv: {},
+    };
+
     _client.getWhitelistedDomains.mockReturnValue(Promise.resolve(null));
 
-    await getWhitelistedDomains();
+    await getWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(_client.getWhitelistedDomains).toBeCalled();
@@ -55,6 +84,9 @@ describe('resolved', () => {
 
 describe('reject', () => {
   it('handle error thrown with only status', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -64,13 +96,16 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getWhitelistedDomains();
+    await getWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
   });
 
   it('handle error thrown by messenger', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       response: {
         status: 400,
@@ -89,7 +124,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getWhitelistedDomains();
+    await getWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(log.error.mock.calls[2][0]).not.toMatch(/\[object Object\]/);
@@ -97,6 +132,9 @@ describe('reject', () => {
   });
 
   it('handle error thrown by ourselves', async () => {
+    const ctx = {
+      argv: {},
+    };
     const error = {
       message: 'something wrong happened',
     };
@@ -104,7 +142,7 @@ describe('reject', () => {
 
     process.exit = jest.fn();
 
-    await getWhitelistedDomains();
+    await getWhitelistedDomains(ctx);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/setMessengerProfile.spec.js
+++ b/src/cli/providers/messenger/__tests__/setMessengerProfile.spec.js
@@ -112,6 +112,26 @@ describe('resolve', () => {
       });
     });
 
+    it('--token should work', async () => {
+      const ctx = {
+        argv: { token: '12345' },
+      };
+
+      await setMessengerProfile(ctx);
+
+      expect(MessengerClient.connect).toBeCalledWith('12345');
+    });
+
+    it('Abbreviational options should work', async () => {
+      const ctx = {
+        argv: { t: '12345' },
+      };
+
+      await setMessengerProfile(ctx);
+
+      expect(MessengerClient.connect).toBeCalledWith('12345');
+    });
+
     it('should set whole profile once', async () => {
       const ctx = {
         argv: {

--- a/src/cli/providers/messenger/__tests__/setWebhook.spec.js
+++ b/src/cli/providers/messenger/__tests__/setWebhook.spec.js
@@ -15,13 +15,16 @@ const getWebhookFromNgrok = require('../../../shared/getWebhookFromNgrok')
 const log = require('../../../shared/log');
 const getConfig = require('../../../shared/getConfig');
 
+const FAKE_TOKEN = '__FAKE_TOKEN__';
 const APP_ID = '__APP_ID__';
 const APP_SECRET = '__APP_SECRET__';
 const VERIFY_TOKEN = '__VERIFY_TOKEN__';
 const WEBHOOK = 'http://example.com/webhook';
+let ACCESS_TOKEN;
 
 const MOCK_FILE_WITH_PLATFORM = {
   messenger: {
+    accessToken: FAKE_TOKEN,
     appId: APP_ID,
     appSecret: APP_SECRET,
     verifyToken: VERIFY_TOKEN,
@@ -66,7 +69,7 @@ describe('resolve', () => {
   it('successfully set webhook and show messages', async () => {
     setup();
 
-    await setWebhook(WEBHOOK, VERIFY_TOKEN);
+    await setWebhook(ACCESS_TOKEN, WEBHOOK, VERIFY_TOKEN);
 
     const logs = log.print.mock.calls.map(call => call[0]);
 
@@ -77,7 +80,7 @@ describe('resolve', () => {
   it('use default fields to setup', async () => {
     const { client } = setup();
 
-    await setWebhook(WEBHOOK, VERIFY_TOKEN);
+    await setWebhook(ACCESS_TOKEN, WEBHOOK, VERIFY_TOKEN);
 
     expect(client.createSubscription).toBeCalledWith({
       app_id: '__APP_ID__',
@@ -99,7 +102,7 @@ describe('resolve', () => {
   it('get ngrok webhook to setup', async () => {
     const { client } = setup();
 
-    await setWebhook(undefined, VERIFY_TOKEN);
+    await setWebhook(ACCESS_TOKEN, undefined, VERIFY_TOKEN);
 
     expect(getWebhookFromNgrok).toBeCalledWith('4040');
     expect(client.createSubscription).toBeCalledWith({
@@ -122,7 +125,17 @@ describe('resolve', () => {
   it('set ngrok webhook port', async () => {
     setup();
 
-    await setWebhook(undefined, VERIFY_TOKEN, '5555');
+    await setWebhook(ACCESS_TOKEN, undefined, VERIFY_TOKEN, '5555');
+
+    expect(getWebhookFromNgrok).toBeCalledWith('5555');
+  });
+
+  it('--token should work', async () => {
+    setup();
+
+    ACCESS_TOKEN = '12345';
+
+    await setWebhook(ACCESS_TOKEN, undefined, VERIFY_TOKEN, '5555');
 
     expect(getWebhookFromNgrok).toBeCalledWith('5555');
   });
@@ -137,7 +150,7 @@ describe('reject', () => {
       verifyToken: '__verifyToken__',
     });
 
-    await setWebhook(WEBHOOK, VERIFY_TOKEN);
+    await setWebhook(ACCESS_TOKEN, WEBHOOK, VERIFY_TOKEN);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
@@ -151,7 +164,7 @@ describe('reject', () => {
       verifyToken: '__verifyToken__',
     });
 
-    await setWebhook(WEBHOOK, VERIFY_TOKEN);
+    await setWebhook(ACCESS_TOKEN, WEBHOOK, VERIFY_TOKEN);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();
@@ -160,7 +173,7 @@ describe('reject', () => {
   it('reject when messenger return not success', async () => {
     setup({ success: false });
 
-    await setWebhook(WEBHOOK, VERIFY_TOKEN);
+    await setWebhook(ACCESS_TOKEN, WEBHOOK, VERIFY_TOKEN);
 
     expect(log.error).toBeCalled();
     expect(process.exit).toBeCalled();

--- a/src/cli/providers/messenger/__tests__/uploadAttachment.spec.js
+++ b/src/cli/providers/messenger/__tests__/uploadAttachment.spec.js
@@ -66,13 +66,24 @@ describe('uploadAttachment', () => {
       expect(log.print).not.toBeCalledWith('bye');
     });
 
-    it('Abbreviational options should work', async () => {
+    it('--token should work', async () => {
       const ctx = {
-        argv: { f: true, y: true },
+        argv: { force: true, yes: true, token: '12345' },
       };
 
       await uploadAttachment(ctx);
 
+      expect(MessengerClient.connect).toBeCalledWith('12345');
+    });
+
+    it('Abbreviational options should work', async () => {
+      const ctx = {
+        argv: { f: true, y: true, t: '12345' },
+      };
+
+      await uploadAttachment(ctx);
+
+      expect(MessengerClient.connect).toBeCalledWith('12345');
       expect(inquirer.prompt).not.toBeCalled();
       expect(log.print).not.toBeCalledWith('bye');
     });

--- a/src/cli/providers/messenger/attachment.js
+++ b/src/cli/providers/messenger/attachment.js
@@ -20,13 +20,14 @@ const help = () => {
 
     ${chalk.dim('Commands:')}
 
-      upload    Upload all the files in assets folder.
-                Bottender will also create a bottender-lock.json file.
+      upload        Upload all the files in assets folder.
+                    Bottender will also create a bottender-lock.json file.
 
     ${chalk.dim('Options:')}
 
       -f, --force   Upload all assets and regenerate bottender-lock.json.
       -y, --yes     Skip prompt confirmation for uploading assets.
+      -t, --token   Specify Messenger access token.
 
     ${chalk.dim('Examples:')}
 
@@ -82,9 +83,11 @@ const logUploadInfo = uploadInfo => {
 };
 
 export async function uploadAttachment(ctx) {
-  const { f, force: _force, y, yes: _yes } = ctx.argv;
+  const { f, force: _force, y, yes: _yes, t, token: _token } = ctx.argv;
   const force = f || _force;
   const yes = y || _yes;
+
+  let accessToken;
 
   try {
     warn(
@@ -93,11 +96,17 @@ export async function uploadAttachment(ctx) {
       )} is under heavy development. API may change between any versions.`
     );
 
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     const files = await readdir('assets', ['.*']);
 

--- a/src/cli/providers/messenger/get-started.js
+++ b/src/cli/providers/messenger/get-started.js
@@ -1,20 +1,58 @@
 /* eslint-disable consistent-return */
 import invariant from 'invariant';
 import { MessengerClient } from 'messaging-api-messenger';
+import chalk from 'chalk';
 
 import getConfig from '../../shared/getConfig';
 import { print, error, bold } from '../../shared/log';
 
-import help from './help';
+const help = () => {
+  console.log(`
+    bottender messenger get-started <command> [option]
 
-export async function getGetStarted() {
+    ${chalk.dim('Commands:')}
+
+      get               Get get_started setting.
+      del, delete       Delete get_started setting.
+
+    ${chalk.dim('Options:')}
+
+      -t, --token       Specify Messenger access token.
+
+    ${chalk.dim('Examples:')}
+
+    ${chalk.dim('-')} Get get_started setting
+
+      ${chalk.cyan('$ bottender messenger get-started get')}
+
+    ${chalk.dim('-')} Delete get_started setting with specific access token
+
+      ${chalk.cyan(
+        '$ bottender messenger get-started delete --token __FAKE_TOKEN__'
+      )}
+  `);
+};
+
+export async function getGetStarted(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
+
     const getStarted = await client.getGetStarted();
+
     if (getStarted && getStarted.payload) {
       print(`Get started payload is: ${bold(getStarted.payload)}`);
     } else {
@@ -34,19 +72,29 @@ export async function getGetStarted() {
   }
 }
 
-export async function deleteGetStarted() {
+export async function deleteGetStarted(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     await client.deleteGetStarted();
 
-    print(`Successfully ${bold('get_started')} setting`);
+    print(`Successfully delete ${bold('get_started')} setting`);
   } catch (err) {
-    error(`Failed to ${bold('get_started')} setting`);
+    error(`Failed to delete ${bold('get_started')} setting`);
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -63,11 +111,11 @@ export default async function main(ctx) {
   const subcommand = ctx.argv._[2];
   switch (subcommand) {
     case 'get':
-      await getGetStarted();
+      await getGetStarted(ctx);
       break;
     case 'delete':
     case 'del':
-      await deleteGetStarted();
+      await deleteGetStarted(ctx);
       break;
     default:
       error(`Please specify a valid subcommand: get, delete`);

--- a/src/cli/providers/messenger/greeting.js
+++ b/src/cli/providers/messenger/greeting.js
@@ -1,21 +1,58 @@
 /* eslint-disable consistent-return */
 import invariant from 'invariant';
 import { MessengerClient } from 'messaging-api-messenger';
+import chalk from 'chalk';
 
 import getConfig from '../../shared/getConfig';
 import { print, error, bold } from '../../shared/log';
 
-import help from './help';
+const help = () => {
+  console.log(`
+    bottender messenger greeting <command> [option]
 
-export async function getGreeting() {
+    ${chalk.dim('Commands:')}
+
+      get               Get greeting setting.
+      del, delete       Delete greeting setting.
+
+    ${chalk.dim('Options:')}
+
+      -t, --token       Specify Messenger access token.
+
+    ${chalk.dim('Examples:')}
+
+    ${chalk.dim('-')} Get greeting setting
+
+      ${chalk.cyan('$ bottender messenger greeting get')}
+
+    ${chalk.dim('-')} Delete greeting setting with specific access token
+
+      ${chalk.cyan(
+        '$ bottender messenger greeting delete --token __FAKE_TOKEN__'
+      )}
+  `);
+};
+
+export async function getGreeting(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     const greeting = await client.getGreeting();
+
     if (greeting && greeting[0] && greeting[0].text) {
       print(`The greeting is: ${bold(greeting[0].text)}`);
     } else {
@@ -35,13 +72,23 @@ export async function getGreeting() {
   }
 }
 
-export async function deleteGreeting() {
+export async function deleteGreeting(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     await client.deleteGreeting();
 
@@ -64,11 +111,11 @@ export default async function main(ctx) {
   const subcommand = ctx.argv._[2];
   switch (subcommand) {
     case 'get':
-      await getGreeting();
+      await getGreeting(ctx);
       break;
     case 'delete':
     case 'del':
-      await deleteGreeting();
+      await deleteGreeting(ctx);
       break;
     default:
       error(`Please specify a valid subcommand: get, delete`);

--- a/src/cli/providers/messenger/persistent-menu.js
+++ b/src/cli/providers/messenger/persistent-menu.js
@@ -2,19 +2,55 @@
 import Table from 'cli-table2';
 import invariant from 'invariant';
 import { MessengerClient } from 'messaging-api-messenger';
+import chalk from 'chalk';
 
 import getConfig from '../../shared/getConfig';
 import { print, error, bold } from '../../shared/log';
 
-import help from './help';
+const help = () => {
+  console.log(`
+    bottender messenger persistent-menu <command> [option]
 
-export async function getPersistentMenu() {
+    ${chalk.dim('Commands:')}
+
+      get               Get persistent-menu setting.
+      del, delete       Delete persistent-menu setting.
+
+    ${chalk.dim('Options:')}
+
+      -t, --token       Specify Messenger access token.
+
+    ${chalk.dim('Examples:')}
+
+    ${chalk.dim('-')} Get persistent-menu setting
+
+      ${chalk.cyan('$ bottender messenger persistent-menu get')}
+
+    ${chalk.dim('-')} Delete persistent-menu setting with specific access token
+
+      ${chalk.cyan(
+        '$ bottender messenger persistent-menu delete --token __FAKE_TOKEN__'
+      )}
+  `);
+};
+
+export async function getPersistentMenu(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     const persistentMenu = await client.getPersistentMenu();
 
@@ -47,13 +83,23 @@ export async function getPersistentMenu() {
   }
 }
 
-export async function deletePersistentMenu() {
+export async function deletePersistentMenu(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     await client.deletePersistentMenu();
 
@@ -76,11 +122,11 @@ export default async function main(ctx) {
   const subcommand = ctx.argv._[2];
   switch (subcommand) {
     case 'get':
-      await getPersistentMenu();
+      await getPersistentMenu(ctx);
       break;
     case 'delete':
     case 'del':
-      await deletePersistentMenu();
+      await deletePersistentMenu(ctx);
       break;
     default:
       error(`Please specify a valid subcommand: get, delete`);

--- a/src/cli/providers/messenger/profile.js
+++ b/src/cli/providers/messenger/profile.js
@@ -34,6 +34,7 @@ export const help = () => {
     ${chalk.dim('Options:')}
 
       --force       Force update the messenger profile by config
+      -t, --token   Specify Messenger access token.
 
     ${chalk.dim('Examples:')}
 
@@ -67,13 +68,23 @@ export function checkMessengerProfile() {
   }
 }
 
-export async function getMessengerProfile() {
+export async function getMessengerProfile(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     const profile = await client.getMessengerProfile(FIELDS);
 
@@ -99,14 +110,22 @@ export async function getMessengerProfile() {
 }
 
 export async function setMessengerProfile(ctx) {
-  const { force } = ctx.argv;
-  try {
-    const { accessToken, profile: _profile } = getConfig(
-      'bottender.config.js',
-      'messenger'
-    );
+  const { force, t, token: _token } = ctx.argv;
 
-    invariant(accessToken, 'accessToken is not found in config file');
+  let accessToken;
+
+  try {
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
+
+      invariant(config.accessToken, 'accessToken is not found in config file');
+
+      accessToken = config.accessToken;
+    }
+
+    const { profile: _profile } = getConfig('bottender.config.js', 'messenger');
 
     const client = MessengerClient.connect(accessToken);
 
@@ -188,13 +207,23 @@ export async function setMessengerProfile(ctx) {
   }
 }
 
-export async function deleteMessengerProfile() {
+export async function deleteMessengerProfile(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     await client.deleteMessengerProfile(FIELDS);
 
@@ -220,14 +249,14 @@ export default async function main(ctx) {
       checkMessengerProfile();
       break;
     case 'get':
-      await getMessengerProfile();
+      await getMessengerProfile(ctx);
       break;
     case 'set':
       await setMessengerProfile(ctx);
       break;
     case 'delete':
     case 'del':
-      await deleteMessengerProfile();
+      await deleteMessengerProfile(ctx);
       break;
     case 'help':
       help();

--- a/src/cli/providers/messenger/whitelisted-domains.js
+++ b/src/cli/providers/messenger/whitelisted-domains.js
@@ -1,19 +1,55 @@
 /* eslint-disable consistent-return */
 import invariant from 'invariant';
 import { MessengerClient } from 'messaging-api-messenger';
+import chalk from 'chalk';
 
 import getConfig from '../../shared/getConfig';
 import { print, error, bold } from '../../shared/log';
 
-import help from './help';
+const help = () => {
+  console.log(`
+    bottender messenger whitelisted-domains <command> [option]
 
-export async function getWhitelistedDomains() {
+    ${chalk.dim('Commands:')}
+
+      get               Get whitelisted-domains setting.
+      del, delete       Delete whitelisted-domains setting.
+
+    ${chalk.dim('Options:')}
+
+      -t, --token       Specify Messenger access token.
+
+    ${chalk.dim('Examples:')}
+
+    ${chalk.dim('-')} Get whitelisted-domains setting
+
+      ${chalk.cyan('$ bottender messenger whitelisted-domains get')}
+
+    ${chalk.dim('-')} Delete persistent-menu setting with specific access token
+
+      ${chalk.cyan(
+        '$ bottender messenger persistent-menu delete --token __FAKE_TOKEN__'
+      )}
+  `);
+};
+
+export async function getWhitelistedDomains(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     const whitelistedDomains = await client.getWhitelistedDomains();
     if (whitelistedDomains) {
@@ -37,13 +73,23 @@ export async function getWhitelistedDomains() {
   }
 }
 
-export async function deleteWhitelistedDomains() {
+export async function deleteWhitelistedDomains(ctx) {
+  const { t, token: _token } = ctx.argv;
+
+  let accessToken;
+
   try {
-    const config = getConfig('bottender.config.js', 'messenger');
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+      invariant(config.accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(config.accessToken);
+      accessToken = config.accessToken;
+    }
+
+    const client = MessengerClient.connect(accessToken);
 
     await client.deleteWhitelistedDomains();
 
@@ -66,11 +112,11 @@ export default async function main(ctx) {
   const subcommand = ctx.argv._[2];
   switch (subcommand) {
     case 'get':
-      await getWhitelistedDomains();
+      await getWhitelistedDomains(ctx);
       break;
     case 'delete':
     case 'del':
-      await deleteWhitelistedDomains();
+      await deleteWhitelistedDomains(ctx);
       break;
     default:
       error(`Please specify a valid subcommand: get, delete`);

--- a/src/cli/providers/telegram/__tests__/deleteWebhook.spec.js
+++ b/src/cli/providers/telegram/__tests__/deleteWebhook.spec.js
@@ -45,8 +45,32 @@ it('be defined', () => {
 });
 
 describe('resolve', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deleteWebhook(ctx);
+
+    expect(TelegramClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deleteWebhook(ctx);
+
+    expect(TelegramClient.connect).toBeCalledWith('12345');
+  });
+
   it('successfully delete webhook', async () => {
-    await deleteWebhook();
+    const ctx = {
+      argv: {},
+    };
+
+    await deleteWebhook(ctx);
 
     expect(log.print).toHaveBeenCalledTimes(1);
     expect(log.print.mock.calls[0][0]).toMatch(/Successfully/);
@@ -54,19 +78,26 @@ describe('resolve', () => {
 });
 
 describe('reject', () => {
-  it('reject when Telegram return not success', async () => {
+  it('reject when Telegram return not success', () => {
+    const ctx = {
+      argv: {},
+    };
+
     TelegramClient.connect().deleteWebhook.mockReturnValueOnce(
       Promise.resolve({
         ok: false,
       })
     );
-    await deleteWebhook();
-    expect(deleteWebhook().then).toThrow();
+
+    expect(deleteWebhook(ctx).then).toThrow();
   });
 
-  it('reject when `accessToken` is not found in config file', async () => {
-    getConfig.mockReturnValueOnce(null);
-    await deleteWebhook();
-    expect(deleteWebhook().then).toThrow();
+  it('reject when accessToken is not found in config file', () => {
+    const ctx = {
+      argv: {},
+    };
+    getConfig.mockReturnValueOnce({});
+
+    expect(deleteWebhook(ctx).then).toThrow();
   });
 });

--- a/src/cli/providers/telegram/__tests__/getWebhook.spec.js
+++ b/src/cli/providers/telegram/__tests__/getWebhook.spec.js
@@ -45,27 +45,58 @@ it('be defined', () => {
 });
 
 describe('resolve', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await getWebhook(ctx);
+
+    expect(TelegramClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await getWebhook(ctx);
+
+    expect(TelegramClient.connect).toBeCalledWith('12345');
+  });
+
   it('successfully get webhook', async () => {
-    await getWebhook();
+    const ctx = {
+      argv: {},
+    };
+
+    await getWebhook(ctx);
 
     expect(log.print).toHaveBeenCalledTimes(4);
   });
 });
 
 describe('reject', () => {
-  it('reject when Telegram return not success', async () => {
+  it('reject when Telegram return not success', () => {
+    const ctx = {
+      argv: {},
+    };
     TelegramClient.connect().getWebhookInfo.mockReturnValueOnce(
       Promise.resolve({
         ok: false,
       })
     );
-    await getWebhook();
-    expect(getWebhook().then).toThrow();
+
+    expect(getWebhook(ctx).then).toThrow();
   });
 
-  it('reject when `accessToken` is not found in config file', async () => {
-    getConfig.mockReturnValueOnce(null);
-    await getWebhook();
-    expect(getWebhook().then).toThrow();
+  it('reject when accessToken is not found in config file', () => {
+    const ctx = {
+      argv: {},
+    };
+
+    getConfig.mockReturnValueOnce({});
+
+    expect(getWebhook(ctx).then).toThrow();
   });
 });

--- a/src/cli/providers/telegram/help.js
+++ b/src/cli/providers/telegram/help.js
@@ -17,6 +17,7 @@ const help = () => {
     ${chalk.dim('Options:')}
 
       -w                    Webhook callback URL
+      -t, --token           Specify Telegram access token.
       --ngrok-port          Ngrok port(default: 4040)
 
     ${chalk.dim('Examples:')}

--- a/src/cli/providers/telegram/webhook.js
+++ b/src/cli/providers/telegram/webhook.js
@@ -8,11 +8,21 @@ import { print, error, bold, warn } from '../../shared/log';
 
 import help from './help';
 
-export async function getWebhook() {
-  try {
-    const { accessToken } = getConfig('bottender.config.js', 'telegram');
+export async function getWebhook(ctx) {
+  const { t, token: _token } = ctx.argv;
 
-    invariant(accessToken, '`accessToken` is not found in config file');
+  let accessToken;
+
+  try {
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'telegram');
+
+      invariant(config.accessToken, 'accessToken is not found in config file');
+
+      accessToken = config.accessToken;
+    }
 
     const client = TelegramClient.connect(accessToken);
     const { ok, result } = await client.getWebhookInfo();
@@ -33,11 +43,23 @@ export async function getWebhook() {
   }
 }
 
-export async function setWebhook(webhook, ngrokPort = '4040') {
-  try {
-    const { accessToken } = getConfig('bottender.config.js', 'telegram');
+export async function setWebhook(ctx) {
+  const { t, token: _token } = ctx.argv;
+  const ngrokPort = ctx.argv['ngrok-port'] || '4040';
 
-    invariant(accessToken, '`accessToken` is not found in config file');
+  let { w: webhook } = ctx.argv;
+  let accessToken;
+
+  try {
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'telegram');
+
+      invariant(config.accessToken, 'accessToken is not found in config file');
+
+      accessToken = config.accessToken;
+    }
 
     const client = TelegramClient.connect(accessToken);
 
@@ -75,11 +97,21 @@ export async function setWebhook(webhook, ngrokPort = '4040') {
   }
 }
 
-export async function deleteWebhook() {
-  try {
-    const { accessToken } = getConfig('bottender.config.js', 'telegram');
+export async function deleteWebhook(ctx) {
+  const { t, token: _token } = ctx.argv;
 
-    invariant(accessToken, '`accessToken` is not found in config file');
+  let accessToken;
+
+  try {
+    if (t || _token) {
+      accessToken = t || _token;
+    } else {
+      const config = getConfig('bottender.config.js', 'telegram');
+
+      invariant(config.accessToken, 'accessToken is not found in config file');
+
+      accessToken = config.accessToken;
+    }
 
     const client = TelegramClient.connect(accessToken);
     const { ok } = await client.deleteWebhook();
@@ -105,17 +137,15 @@ export default async function main(ctx) {
 
   switch (subcommand) {
     case 'get':
-      await getWebhook();
+      await getWebhook(ctx);
       break;
     case 'set': {
-      const webhook = ctx.argv.w;
-      const ngrokPort = ctx.argv['ngrok-port'];
-      await setWebhook(webhook, ngrokPort);
+      await setWebhook(ctx);
       break;
     }
     case 'delete':
     case 'del':
-      await deleteWebhook();
+      await deleteWebhook(ctx);
       break;
     default:
       error(`Please specify a valid subcommand: get, set, delete`);

--- a/src/cli/providers/viber/__tests__/deleteWebhook.spec.js
+++ b/src/cli/providers/viber/__tests__/deleteWebhook.spec.js
@@ -37,8 +37,32 @@ it('be defined', () => {
 });
 
 describe('resolve', () => {
+  it('--token should work', async () => {
+    const ctx = {
+      argv: { token: '12345' },
+    };
+
+    await deleteWebhook(ctx);
+
+    expect(ViberClient.connect).toBeCalledWith('12345');
+  });
+
+  it('Abbreviational options should work', async () => {
+    const ctx = {
+      argv: { t: '12345' },
+    };
+
+    await deleteWebhook(ctx);
+
+    expect(ViberClient.connect).toBeCalledWith('12345');
+  });
+
   it('successfully delete webhook', async () => {
-    await deleteWebhook();
+    const ctx = {
+      argv: {},
+    };
+
+    await deleteWebhook(ctx);
 
     expect(log.print).toHaveBeenCalledTimes(1);
     expect(log.print.mock.calls[0][0]).toMatch(/Successfully/);
@@ -46,17 +70,25 @@ describe('resolve', () => {
 });
 
 describe('reject', () => {
-  it('reject when Viber return not success', async () => {
+  it('reject when Viber return not success', () => {
+    const ctx = {
+      argv: {},
+    };
+
     ViberClient.connect().removeWebhook.mockReturnValueOnce(
       Promise.reject(new Error('removeWebhook failed'))
     );
 
-    expect(deleteWebhook().then).toThrow();
+    expect(deleteWebhook(ctx).then).toThrow();
   });
 
-  it('reject when `accessToken` is not found in config file', async () => {
+  it('reject when `accessToken` is not found in config file', () => {
+    const ctx = {
+      argv: {},
+    };
+
     getConfig.mockReturnValueOnce(null);
 
-    expect(deleteWebhook().then).toThrow();
+    expect(deleteWebhook(ctx).then).toThrow();
   });
 });

--- a/src/cli/providers/viber/__tests__/setWebhook.spec.js
+++ b/src/cli/providers/viber/__tests__/setWebhook.spec.js
@@ -23,12 +23,18 @@ const MOCK_FILE_WITH_PLATFORM = {
 const _exit = process.exit;
 
 const setup = (
-  { webhook = 'http://example.com/webhook', eventTypes = [] } = {
+  {
+    webhook = 'http://example.com/webhook',
+    eventTypes = [],
+    accessToken = undefined,
+  } = {
     webhook: 'http://example.com/webhook',
     eventTypes: [],
+    accessToken: undefined,
   }
 ) => ({
   webhook,
+  accessToken,
   eventTypes,
 });
 
@@ -70,11 +76,11 @@ it('be defined', () => {
 
 describe('resolve', () => {
   it('successfully set webhook', async () => {
-    const { webhook, eventTypes } = setup({
+    const { webhook, accessToken, eventTypes } = setup({
       eventTypes: ['delivered', 'seen'],
     });
 
-    await setWebhook(webhook, undefined, eventTypes);
+    await setWebhook(webhook, undefined, accessToken, eventTypes);
 
     expect(ViberClient.connect().setWebhook).toBeCalledWith(
       webhook,
@@ -82,6 +88,14 @@ describe('resolve', () => {
     );
     expect(log.print).toHaveBeenCalledTimes(1);
     expect(log.print.mock.calls[0][0]).toMatch(/Successfully/);
+  });
+
+  it('-t --token should work', async () => {
+    const { webhook, accessToken } = setup({ accessToken: '12345' });
+
+    await setWebhook(webhook, undefined, accessToken);
+
+    expect(ViberClient.connect).toBeCalledWith('12345');
   });
 
   it('get ngrok webhook to setup', async () => {
@@ -104,16 +118,14 @@ describe('resolve', () => {
 });
 
 describe('reject', () => {
-  it('reject when `accessToken` not found in config file', async () => {
+  it('reject when accessToken not found in config file', async () => {
     const { webhook } = setup();
     getConfig.mockReturnValue({});
     process.exit = jest.fn();
 
     await setWebhook(webhook);
 
-    expect(log.error).toBeCalledWith(
-      '`accessToken` is not found in config file'
-    );
+    expect(log.error).toBeCalledWith('accessToken is not found in config file');
     expect(process.exit).toBeCalled();
   });
 

--- a/src/cli/providers/viber/help.js
+++ b/src/cli/providers/viber/help.js
@@ -17,6 +17,7 @@ const help = () => {
 
       -w                    Webhook callback URL
       -e                    The types of Viber events. Seperate events by comma (e.g. delivered,seen)
+      -t, --token           Specify Viber access token.
       --ngrok-port          Ngrok port(default: 4040)
 
     ${chalk.dim('Examples:')}


### PR DESCRIPTION
close #123

1. Add option `-t, --token` to all Messenger commands in CLI.
e.g. `bottender messenger greeting delete --token __FAKE_TOKEN__`
2. Add specific help message to all Messenger commands in CLI.