### PR TITLE
Support trigger payload in ConsoleBot

### DIFF
--- a/src/bot/ConsoleBot.js
+++ b/src/bot/ConsoleBot.js
@@ -28,13 +28,23 @@ export default class ConsoleBot extends Bot {
         process.exit();
       }
 
-      await Promise.resolve(
-        requestHandler({
+      let rawEvent;
+
+      if (/^\/payload /.test(line)) {
+        const payload = line.split('/payload ')[1];
+
+        rawEvent = {
+          payload,
+        };
+      } else {
+        rawEvent = {
           message: {
             text: line,
           },
-        })
-      );
+        };
+      }
+
+      await Promise.resolve(requestHandler(rawEvent));
 
       process.stdout.write('You > ');
       rl.once('line', handleLine);

--- a/src/bot/__tests__/ConsoleBot.spec.js
+++ b/src/bot/__tests__/ConsoleBot.spec.js
@@ -62,4 +62,46 @@ describe('createRuntime', () => {
 
     expect(process.exit).toBeCalled();
   });
+
+  it('should call handler with text event when receive random text', async () => {
+    const bot = new ConsoleBot();
+
+    let context;
+    bot.onEvent(ctx => {
+      context = ctx;
+    });
+
+    readline.createInterface.mockReturnValue({
+      once: once((string, fn) => fn('random text')),
+      close: jest.fn(),
+    });
+
+    bot.createRuntime();
+
+    await new Promise(process.nextTick);
+
+    expect(context.event.isText).toBe(true);
+    expect(context.event.text).toBe('random text');
+  });
+
+  it('should call handler with payload event when receive /payload <payload>', async () => {
+    const bot = new ConsoleBot();
+
+    let context;
+    bot.onEvent(ctx => {
+      context = ctx;
+    });
+
+    readline.createInterface.mockReturnValue({
+      once: once((string, fn) => fn('/payload A_PAYLOAD')),
+      close: jest.fn(),
+    });
+
+    bot.createRuntime();
+
+    await new Promise(process.nextTick);
+
+    expect(context.event.isPayload).toBe(true);
+    expect(context.event.payload).toBe('A_PAYLOAD');
+  });
 });

--- a/src/context/ConsoleEvent.js
+++ b/src/context/ConsoleEvent.js
@@ -7,7 +7,8 @@ type Message = {
 };
 
 export type ConsoleRawEvent = {
-  message: Message,
+  message?: Message,
+  payload?: string,
 };
 
 export default class ConsoleEvent implements Event {
@@ -30,15 +31,15 @@ export default class ConsoleEvent implements Event {
    *
    */
   get isMessage(): boolean {
-    return true;
+    return !!this._rawEvent.message;
   }
 
   /**
    * The message object from Console raw event.
    *
    */
-  get message(): Message {
-    return this._rawEvent.message;
+  get message(): ?Message {
+    return this._rawEvent.message || null;
   }
 
   /**
@@ -46,14 +47,36 @@ export default class ConsoleEvent implements Event {
    *
    */
   get isText(): boolean {
-    return true;
+    if (this.isMessage) {
+      return true;
+    }
+    return false;
   }
 
   /**
    * The text string from Console raw event.
    *
    */
-  get text(): string {
-    return (this.message: any).text;
+  get text(): ?string {
+    if (this.isText) {
+      return ((this.message: any): Message).text;
+    }
+    return null;
+  }
+
+  /**
+   * Determine if the event is a payload event.
+   *
+   */
+  get isPayload(): boolean {
+    return !!this._rawEvent.payload;
+  }
+
+  /**
+   * The payload string from Console raw event.
+   *
+   */
+  get payload(): ?string {
+    return this._rawEvent.payload || null;
   }
 }

--- a/src/context/__tests__/ConsoleEvent.spec.js
+++ b/src/context/__tests__/ConsoleEvent.spec.js
@@ -6,24 +6,43 @@ const textMessage = {
   },
 };
 
+const payload = {
+  payload: 'A_PAYLOAD',
+};
+
 it('#rawEvent', () => {
   expect(new ConsoleEvent(textMessage).rawEvent).toEqual(textMessage);
+  expect(new ConsoleEvent(payload).rawEvent).toEqual(payload);
 });
 
 it('#isMessage', () => {
   expect(new ConsoleEvent(textMessage).isMessage).toEqual(true);
+  expect(new ConsoleEvent(payload).isMessage).toEqual(false);
 });
 
 it('#message', () => {
   expect(new ConsoleEvent(textMessage).message).toEqual({
     text: 'Hello, world',
   });
+  expect(new ConsoleEvent(payload).message).toEqual(null);
 });
 
 it('#isText', () => {
   expect(new ConsoleEvent(textMessage).isText).toEqual(true);
+  expect(new ConsoleEvent(payload).isText).toEqual(false);
 });
 
 it('text', () => {
   expect(new ConsoleEvent(textMessage).text).toEqual('Hello, world');
+  expect(new ConsoleEvent(payload).text).toEqual(null);
+});
+
+it('#isPayload', () => {
+  expect(new ConsoleEvent(textMessage).isPayload).toEqual(false);
+  expect(new ConsoleEvent(payload).isPayload).toEqual(true);
+});
+
+it('payload', () => {
+  expect(new ConsoleEvent(textMessage).payload).toEqual(null);
+  expect(new ConsoleEvent(payload).payload).toEqual('A_PAYLOAD');
 });


### PR DESCRIPTION
In console:

```
You > /payload PAYLOAD
```

Receive event:

```js
context.event.isMessage // false
context.event.message // null
context.event.isText // false
context.event.text // null

context.event.isPayload // true
context.event.payload // PAYLOAD
```