### PR TITLE
fix error  when verifying facebook signature

### DIFF
--- a/src/bot/MessengerConnector.js
+++ b/src/bot/MessengerConnector.js
@@ -289,7 +289,13 @@ export default class MessengerConnector
       return true;
     }
 
-    const bufferFromSignature = Buffer.from(signature.split('sha1=')[1], 'hex');
+    if (typeof signature !== 'string') return false;
+
+    const sha1 = signature.split('sha1=')[1];
+
+    if (!sha1) return false;
+
+    const bufferFromSignature = Buffer.from(sha1, 'hex');
 
     const hashBufferFromBody = crypto
       .createHmac('sha1', this._appSecret)

--- a/src/bot/__tests__/MessengerConnector.spec.js
+++ b/src/bot/__tests__/MessengerConnector.spec.js
@@ -543,4 +543,20 @@ describe('#verifySignature', () => {
 
     expect(result).toBe(true);
   });
+
+  it('should return false if signature is undefined', () => {
+    const { connector } = setup();
+
+    const result = connector.verifySignature('rawBody', undefined);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return false if signature dont have a sha1= prefix', () => {
+    const { connector } = setup();
+
+    const result = connector.verifySignature('rawBody', 'sha256!!!');
+
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
Fix call `.split` on a non-string value and also

`TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.`