### PR TITLE
support pass verifyToken to MessengerBot or MessengerConnector

### DIFF
--- a/src/bot/MessengerBot.js
+++ b/src/bot/MessengerBot.js
@@ -12,17 +12,20 @@ export default class MessengerBot extends Bot {
     sessionStore,
     sync,
     mapPageToAccessToken,
+    verifyToken,
   }: {
     accessToken: string,
     appSecret: string,
     sessionStore: SessionStore,
     sync?: boolean,
     mapPageToAccessToken?: (pageId: string) => Promise<string>,
+    verifyToken?: string,
   }) {
     const connector = new MessengerConnector({
       accessToken,
       appSecret,
       mapPageToAccessToken,
+      verifyToken,
     });
     super({ connector, sessionStore, sync });
   }

--- a/src/bot/MessengerConnector.js
+++ b/src/bot/MessengerConnector.js
@@ -78,6 +78,7 @@ type ConstructorOptions = {|
   appSecret?: string,
   client?: MessengerClient,
   mapPageToAccessToken?: (pageId: string) => Promise<string>,
+  verifyToken?: ?string,
 |};
 
 export default class MessengerConnector
@@ -85,16 +86,19 @@ export default class MessengerConnector
   _client: MessengerClient;
   _appSecret: string;
   _mapPageToAccessToken: ?(pageId: string) => ?Promise<string>;
+  _verifyToken: ?string;
 
   constructor({
     accessToken,
     appSecret,
     client,
     mapPageToAccessToken,
+    verifyToken,
   }: ConstructorOptions) {
     this._client = client || MessengerClient.connect(accessToken || '');
     this._appSecret = appSecret || '';
     this._mapPageToAccessToken = mapPageToAccessToken;
+    this._verifyToken = verifyToken;
     if (!this._appSecret) {
       warning(
         false,
@@ -159,6 +163,10 @@ export default class MessengerConnector
 
   get client(): MessengerClient {
     return this._client;
+  }
+
+  get verifyToken(): ?string {
+    return this._verifyToken;
   }
 
   getUniqueSessionKey(body: MessengerRequestBody): ?string {

--- a/src/bot/__tests__/MessengerConnector.spec.js
+++ b/src/bot/__tests__/MessengerConnector.spec.js
@@ -164,10 +164,11 @@ const webhookTestRequest = {
 };
 
 function setup(
-  { accessToken, appSecret, mapPageToAccessToken } = {
+  { accessToken, appSecret, mapPageToAccessToken, verifyToken } = {
     accessToken: ACCESS_TOKEN,
     appSecret: APP_SECRET,
     mapPageToAccessToken: jest.fn(),
+    verifyToken: undefined,
   }
 ) {
   const mockGraphAPIClient = {
@@ -181,6 +182,7 @@ function setup(
       accessToken,
       appSecret,
       mapPageToAccessToken,
+      verifyToken,
     }),
   };
 }
@@ -199,6 +201,18 @@ describe('#platform', () => {
   it('should be messenger', () => {
     const { connector } = setup();
     expect(connector.platform).toBe('messenger');
+  });
+});
+
+describe('#verifyToken', () => {
+  it('should be undefined when not be provided', () => {
+    const { connector } = setup();
+    expect(connector.verifyToken).toBe(undefined);
+  });
+
+  it('should equal when be provided', () => {
+    const { connector } = setup({ verifyToken: '1234' });
+    expect(connector.verifyToken).toBe('1234');
   });
 });
 

--- a/src/express/registerRoutes.js
+++ b/src/express/registerRoutes.js
@@ -17,7 +17,8 @@ function registerRoutes(server, bot, config = {}) {
   const middleware = config.webhookMiddleware ? [config.webhookMiddleware] : [];
 
   if (bot.connector.platform === 'messenger') {
-    verifyToken = config.verifyToken || shortid.generate();
+    verifyToken =
+      config.verifyToken || bot.connector.verifyToken || shortid.generate();
     server.get(path, verifyMessengerWebhook({ verifyToken }));
     middleware.unshift(verifyMessengerSignature(bot));
   } else if (bot.connector.platform === 'slack') {

--- a/src/koa/registerRoutes.js
+++ b/src/koa/registerRoutes.js
@@ -20,7 +20,8 @@ function registerRoutes(server, bot, config = {}) {
   const middleware = config.webhookMiddleware ? [config.webhookMiddleware] : [];
 
   if (bot.connector.platform === 'messenger') {
-    verifyToken = config.verifyToken || shortid.generate();
+    verifyToken =
+      config.verifyToken || bot.connector.verifyToken || shortid.generate();
     router.get(path, verifyMessengerWebhook({ verifyToken }));
     middleware.unshift(verifyMessengerSignature(bot));
   } else if (bot.connector.platform === 'slack') {

--- a/src/micro/createServer.js
+++ b/src/micro/createServer.js
@@ -6,7 +6,8 @@ import connectNgrok from '../connectNgrok';
 import createRequestHandler from './createRequestHandler';
 
 function createServer(bot, config = {}) {
-  config.verifyToken = config.verifyToken || shortid.generate();
+  config.verifyToken =
+    config.verifyToken || bot.connector.verifyToken || shortid.generate();
 
   const server = micro(createRequestHandler(bot, config));
 

--- a/src/restify/registerRoutes.js
+++ b/src/restify/registerRoutes.js
@@ -17,7 +17,8 @@ function registerRoutes(server, bot, config = {}) {
   const middleware = config.webhookMiddleware ? [config.webhookMiddleware] : [];
 
   if (bot.connector.platform === 'messenger') {
-    verifyToken = config.verifyToken || shortid.generate();
+    verifyToken =
+      config.verifyToken || bot.connector.verifyToken || shortid.generate();
     server.get(path, verifyMessengerWebhook({ verifyToken }));
     middleware.unshift(verifyMessengerSignature(bot));
   } else if (bot.connector.platform === 'slack') {


### PR DESCRIPTION
Support both:

- pass verifyToken in server config

```js
const bot = new MessengerBot({
  accessToken: config.accessToken,
  appSecret: config.appSecret,
});

const server = createServer(bot, { verifyToken: config.verifyToken });
```

- pass verifyToken in bot config

```js
new MessengerBot({
  accessToken: config.accessToken,
  appSecret: config.appSecret,
  verifyToken: config.verifyToken
});

const server = createServer(bot);
```