### PR TITLE
fix pass metadata in handover methods

### DIFF
--- a/src/context/MessengerContext.js
+++ b/src/context/MessengerContext.js
@@ -182,7 +182,7 @@ class MessengerContext extends Context implements PlatformContext {
   /**
    * https://github.com/Yoctol/messaging-apis/tree/master/packages/messaging-api-messenger#passthreadcontroltopageinboxuserid-metadata---official-docs
    */
-  async passThreadControlToPageInbox(): Promise<any> {
+  async passThreadControlToPageInbox(metadata?: string): Promise<any> {
     if (!this._session) {
       warning(
         false,
@@ -193,15 +193,19 @@ class MessengerContext extends Context implements PlatformContext {
 
     this._isHandled = true;
 
-    return this._client.passThreadControlToPageInbox(this._session.user.id, {
-      access_token: this._customAccessToken,
-    });
+    return this._client.passThreadControlToPageInbox(
+      this._session.user.id,
+      metadata,
+      {
+        access_token: this._customAccessToken,
+      }
+    );
   }
 
   /**
    * https://github.com/Yoctol/messaging-apis/tree/master/packages/messaging-api-messenger#takethreadcontroluserid-metadata---official-docs
    */
-  async takeThreadControl(): Promise<any> {
+  async takeThreadControl(metadata?: string): Promise<any> {
     if (!this._session) {
       warning(
         false,
@@ -212,7 +216,7 @@ class MessengerContext extends Context implements PlatformContext {
 
     this._isHandled = true;
 
-    return this._client.takeThreadControl(this._session.user.id, {
+    return this._client.takeThreadControl(this._session.user.id, metadata, {
       access_token: this._customAccessToken,
     });
   }
@@ -220,7 +224,7 @@ class MessengerContext extends Context implements PlatformContext {
   /**
    * https://github.com/Yoctol/messaging-apis/blob/master/packages/messaging-api-messenger/README.md#requestthreadcontroluserid-metadata---official-docs
    */
-  async requestThreadControl(): Promise<any> {
+  async requestThreadControl(metadata?: string): Promise<any> {
     if (!this._session) {
       warning(
         false,
@@ -231,7 +235,7 @@ class MessengerContext extends Context implements PlatformContext {
 
     this._isHandled = true;
 
-    return this._client.requestThreadControl(this._session.user.id, {
+    return this._client.requestThreadControl(this._session.user.id, metadata, {
       access_token: this._customAccessToken,
     });
   }

--- a/src/context/__tests__/MessengerContext.spec.js
+++ b/src/context/__tests__/MessengerContext.spec.js
@@ -903,7 +903,7 @@ describe('#passThreadControl', () => {
   it('should call warning if dont have session', async () => {
     const { context, client } = setup({ session: false });
 
-    await context.passThreadControl(263902037430900, 'metadata');
+    await context.passThreadControl(263902037430900);
 
     expect(warning).toBeCalled();
     expect(client.passThreadControl).not.toBeCalled();
@@ -914,10 +914,11 @@ describe('#passThreadControlToPageInbox', () => {
   it('should call to pass user thread control to page inbox', async () => {
     const { context, client, session } = setup();
 
-    await context.passThreadControlToPageInbox();
+    await context.passThreadControlToPageInbox('metadata');
 
     expect(client.passThreadControlToPageInbox).toBeCalledWith(
       session.user.id,
+      'metadata',
       {
         access_token: undefined,
       }
@@ -934,6 +935,7 @@ describe('#passThreadControlToPageInbox', () => {
 
     expect(client.passThreadControlToPageInbox).toBeCalledWith(
       session.user.id,
+      undefined,
       {
         access_token: 'anyToken',
       }
@@ -954,11 +956,15 @@ describe('#takeThreadControl', () => {
   it('should call to take user thread control back', async () => {
     const { context, client, session } = setup();
 
-    await context.takeThreadControl();
+    await context.takeThreadControl('metadata');
 
-    expect(client.takeThreadControl).toBeCalledWith(session.user.id, {
-      access_token: undefined,
-    });
+    expect(client.takeThreadControl).toBeCalledWith(
+      session.user.id,
+      'metadata',
+      {
+        access_token: undefined,
+      }
+    );
   });
 
   it('should call warning if dont have session', async () => {
@@ -975,11 +981,15 @@ describe('#requestThreadControl', () => {
   it('should call to request user thread control', async () => {
     const { context, client, session } = setup();
 
-    await context.requestThreadControl();
+    await context.requestThreadControl('metadata');
 
-    expect(client.requestThreadControl).toBeCalledWith(session.user.id, {
-      access_token: undefined,
-    });
+    expect(client.requestThreadControl).toBeCalledWith(
+      session.user.id,
+      'metadata',
+      {
+        access_token: undefined,
+      }
+    );
   });
 
   it('should call warning if dont have session', async () => {


### PR DESCRIPTION
`metadata` should be passed as second argument.