### PR TITLE
deepClone when read from MemoryCacheStore

### DIFF
--- a/src/cache/MemoryCacheStore.js
+++ b/src/cache/MemoryCacheStore.js
@@ -13,7 +13,12 @@ export default class MemoryCacheStore implements CacheStore {
   }
 
   async get(key: string): Promise<mixed> {
-    const value = await this._lru.get(key);
+    const _value = this._lru.get(key);
+
+    // cloneDeep: To make sure read as different object to prevent
+    // reading same key multiple times, causing freezed by other events.
+    const value = typeof _value === 'object' ? cloneDeep(_value) : _value;
+
     return value || null;
   }
 

--- a/src/cache/__tests__/MemoryCacheStore.spec.js
+++ b/src/cache/__tests__/MemoryCacheStore.spec.js
@@ -8,6 +8,18 @@ describe('#get', () => {
     expect(await store.get('x')).toBe('abc');
   });
 
+  it('should get different object when get multiple times', async () => {
+    const store = new MemoryCacheStore(5);
+
+    await store.put('x', { a: 1 }, 5);
+
+    const result1 = await store.get('x');
+    const result2 = await store.get('x');
+
+    expect(result1).not.toBe(result2);
+    expect(result1).toEqual(result2);
+  });
+
   it('should get null when value does not exist', async () => {
     const store = new MemoryCacheStore(5);
 


### PR DESCRIPTION
cloneDeep: To make sure read as different object to prevent reading same key multiple times, causing freezed by other events.

fix #221
maybe related with #231 