### PR TITLE
rename localClient to ngrokAxios in getWebhookFromNgrok

### DIFF
--- a/src/cli/shared/getWebhookFromNgrok.js
+++ b/src/cli/shared/getWebhookFromNgrok.js
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import get from 'lodash/get';
 
-export default async function(ngrokPort) {
-  const localClient = axios.create({
+export default async function getWebhookFromNgrok(ngrokPort) {
+  const ngrokAxios = axios.create({
     baseURL: `http://localhost:${ngrokPort}`,
   });
 
-  const res = await localClient.get('/api/tunnels');
+  const res = await ngrokAxios.get('/api/tunnels');
   return get(res, 'data.tunnels[1].public_url'); // tunnels[1] return `https` protocol
 }


### PR DESCRIPTION
`ngrokAxios` looks better to me.