### PR TITLE
Add isRequestThreadControlFromInbox

### DIFF
--- a/src/context/MessengerEvent.js
+++ b/src/context/MessengerEvent.js
@@ -701,6 +701,19 @@ export default class MessengerEvent implements Event {
   }
 
   /**
+   * Determine if the event is a request thread control event sent by facebook integrated inbox (appId is 263902037430900).
+   *
+   */
+  get isRequestThreadControlFromInbox(): boolean {
+    return (
+      !!this._rawEvent.request_thread_control &&
+      typeof this._rawEvent.request_thread_control === 'object' &&
+      this._rawEvent.request_thread_control.requested_owner_app_id ===
+        263902037430900
+    );
+  }
+
+  /**
    * The take thread control object from Messenger raw event.
    *
    */

--- a/src/context/__tests__/MessengerEvent.spec.js
+++ b/src/context/__tests__/MessengerEvent.spec.js
@@ -486,7 +486,21 @@ const requestThreadControl = {
   },
   timestamp: 1458692752478,
   request_thread_control: {
-    requested_owner_app_id: '123456789',
+    requested_owner_app_id: 123456789,
+    metadata: 'additional content that the caller wants to set',
+  },
+};
+
+const requestThreadControlFromInbox = {
+  sender: {
+    id: '404217156637689',
+  },
+  recipient: {
+    id: '1423587017700273',
+  },
+  timestamp: 1458692752478,
+  request_thread_control: {
+    requested_owner_app_id: 263902037430900,
     metadata: 'additional content that the caller wants to set',
   },
 };
@@ -1218,13 +1232,29 @@ it('#isRequestThreadControl', () => {
   ).toEqual(true);
 });
 
+it('#isRequestThreadControlFromInbox', () => {
+  expect(
+    new MessengerEvent(textMessage).isRequestThreadControlFromInbox
+  ).toEqual(false);
+  expect(new MessengerEvent(postback).isRequestThreadControlFromInbox).toEqual(
+    false
+  );
+  expect(
+    new MessengerEvent(requestThreadControlFromInbox).isRequestThreadControl
+  ).toEqual(true);
+  expect(
+    new MessengerEvent(requestThreadControlFromInbox)
+      .isRequestThreadControlFromInbox
+  ).toEqual(true);
+});
+
 it('#requestThreadControl', () => {
   expect(new MessengerEvent(textMessage).requestThreadControl).toEqual(null);
   expect(new MessengerEvent(postback).requestThreadControl).toEqual(null);
   expect(new MessengerEvent(requestThreadControl).requestThreadControl).toEqual(
     {
       metadata: 'additional content that the caller wants to set',
-      requested_owner_app_id: '123456789',
+      requested_owner_app_id: 123456789,
     }
   );
 });


### PR DESCRIPTION
I think it would be nice if we can have isRequestThreadControlFromInbox, which determine if the requestThreadControl is sent from facebook integrated inbox.

Also, I modify some test cases according to the official document here: [request_thread_control](https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_handovers/#request_thread_control)