### PR TITLE
fix console falsy getters

### DIFF
--- a/src/context/ConsoleContext.js
+++ b/src/context/ConsoleContext.js
@@ -38,7 +38,7 @@ export default class ConsoleContext extends Context implements PlatformContext {
       // $FlowExpectedError
       return new Proxy(this, {
         get(target, key) {
-          if (target[key]) {
+          if (target[key] !== undefined) {
             return target[key];
           }
 

--- a/src/context/__tests__/ConsoleContext.spec.js
+++ b/src/context/__tests__/ConsoleContext.spec.js
@@ -112,6 +112,12 @@ describe('method missing', () => {
     expect(context.handlerDidEnd).toBeUndefined();
     expect(context.then).toBeUndefined();
   });
+
+  it('should not proxy falsy getters', async () => {
+    const { context } = setup({ fallbackMethods: true });
+
+    expect(context.isSessionWritten).toBe(false);
+  });
 });
 
 describe('#typing', () => {


### PR DESCRIPTION
fix irrelevant warning when using `ConsoleBot` with `context.setState` and `context.resetState`