### PR TITLE
add config to override consoleBot platform

### DIFF
--- a/src/bot/ConsoleBot.js
+++ b/src/bot/ConsoleBot.js
@@ -10,8 +10,13 @@ export default class ConsoleBot extends Bot {
   constructor({
     sessionStore,
     fallbackMethods,
-  }: { sessionStore: SessionStore, fallbackMethods?: boolean } = {}) {
-    const connector = new ConsoleConnector({ fallbackMethods });
+    mockPlatform,
+  }: {
+    sessionStore: SessionStore,
+    fallbackMethods?: boolean,
+    mockPlatform?: string,
+  } = {}) {
+    const connector = new ConsoleConnector({ fallbackMethods, mockPlatform });
     super({ connector, sessionStore, sync: true });
   }
 

--- a/src/bot/ConsoleConnector.js
+++ b/src/bot/ConsoleConnector.js
@@ -12,6 +12,7 @@ type ConsoleRequestBody = ConsoleRawEvent;
 type ConstructorOptions = {|
   client?: ConsoleClient,
   fallbackMethods?: boolean,
+  mockPlatform?: string,
 |};
 
 export default class ConsoleConnector implements Connector<ConsoleRequestBody> {
@@ -19,17 +20,24 @@ export default class ConsoleConnector implements Connector<ConsoleRequestBody> {
 
   _fallbackMethods: boolean;
 
-  constructor({ client, fallbackMethods }: ConstructorOptions = {}) {
+  _platform: string;
+
+  constructor({
+    client,
+    fallbackMethods,
+    mockPlatform,
+  }: ConstructorOptions = {}) {
     this._client = client || {
       sendText: text => {
         process.stdout.write(`Bot > ${text}\n`);
       },
     };
     this._fallbackMethods = fallbackMethods || false;
+    this._platform = mockPlatform || 'console';
   }
 
   get platform(): string {
-    return 'console';
+    return this._platform;
   }
 
   get client(): ConsoleClient {

--- a/src/bot/__tests__/ConsoleConnector.spec.js
+++ b/src/bot/__tests__/ConsoleConnector.spec.js
@@ -8,16 +8,23 @@ const request = {
   },
 };
 
-function setup() {
+function setup(option) {
   return {
-    connector: new ConsoleConnector(),
+    connector: new ConsoleConnector(option),
   };
 }
 
 describe('#platform', () => {
-  it('should be console', () => {
+  it('should be console, when no extra option set', () => {
     const { connector } = setup();
     expect(connector.platform).toBe('console');
+  });
+
+  it('should be overide by mockPlatform setting', () => {
+    const { connector } = setup({
+      mockPlatform: 'messenger',
+    });
+    expect(connector.platform).toBe('messenger');
   });
 });
 


### PR DESCRIPTION
add config to override platform in console bot mode, which makes it easier to check through the bot while doing multi-platform developing.