### PR TITLE
pass mockPlatform to context

### DIFF
--- a/src/bot/ConsoleConnector.js
+++ b/src/bot/ConsoleConnector.js
@@ -80,6 +80,7 @@ export default class ConsoleConnector implements Connector<ConsoleRequestBody> {
       ...params,
       client: this._client,
       fallbackMethods: this._fallbackMethods,
+      mockPlatform: this._platform,
     });
   }
 }

--- a/src/context/ConsoleContext.js
+++ b/src/context/ConsoleContext.js
@@ -15,6 +15,7 @@ type Options = {|
   initialState: ?Object,
   requestContext: ?Object,
   fallbackMethods: boolean,
+  mockPlatform: string,
 |};
 
 const methodBlackList = [
@@ -31,6 +32,8 @@ export default class ConsoleContext extends Context implements PlatformContext {
 
   _fallbackMethods: boolean = false;
 
+  _mockPlatform: string = 'console';
+
   constructor({
     client,
     event,
@@ -38,8 +41,10 @@ export default class ConsoleContext extends Context implements PlatformContext {
     initialState,
     requestContext,
     fallbackMethods,
+    mockPlatform,
   }: Options) {
     super({ client, event, session, initialState, requestContext });
+    this._mockPlatform = mockPlatform;
     this._fallbackMethods = fallbackMethods;
     if (fallbackMethods) {
       // $FlowExpectedError
@@ -67,7 +72,7 @@ export default class ConsoleContext extends Context implements PlatformContext {
    *
    */
   get platform(): string {
-    return 'console';
+    return this._mockPlatform || 'console';
   }
 
   /**

--- a/src/context/__tests__/ConsoleContext.spec.js
+++ b/src/context/__tests__/ConsoleContext.spec.js
@@ -29,7 +29,9 @@ const userSession = {
   },
 };
 
-const setup = ({ session, fallbackMethods } = { session: userSession }) => {
+const setup = (
+  { session, fallbackMethods, mockPlatform } = { session: userSession }
+) => {
   const client = {
     sendText: jest.fn(),
   };
@@ -38,6 +40,7 @@ const setup = ({ session, fallbackMethods } = { session: userSession }) => {
     event: new ConsoleEvent(rawEvent),
     session,
     fallbackMethods: fallbackMethods || false,
+    mockPlatform,
   });
   return {
     client,
@@ -51,9 +54,14 @@ it('be defined', () => {
   expect(context).toBeDefined();
 });
 
-it('#platform to be `console`', () => {
+it('#platform to be `console` by default', () => {
   const { context } = setup();
   expect(context.platform).toBe('console');
+});
+
+it('#platform to be `console` by mockPlatform', () => {
+  const { context } = setup({ mockPlatform: 'messenger' });
+  expect(context.platform).toBe('messenger');
 });
 
 it('get #session works', () => {


### PR DESCRIPTION
pass mockPlatform to context, makes `context.platform` consistent with `context.session.platform` 