### PR TITLE
Add with-rxjs example

### DIFF
--- a/examples/with-rxjs/README.md
+++ b/examples/with-rxjs/README.md
@@ -1,0 +1,23 @@
+# With RxJS
+
+## Install and Run
+
+Download this example or clone [bottender](https://github.com/Yoctol/bottender).
+
+```
+curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/with-rxjs
+cd with-rxjs
+npm install
+npm run dev
+```
+
+## Idea of this example
+
+[RxJS](https://rxjs-dev.firebaseapp.com/) is a library for reactive programming using Observables. It's good at working with asynchronous data streams and treats everything as a stream ordered in time. 
+
+This is an exmaple for integrating Bottender with RxJS. This shows how to get the last message after user stops entering for one second. It would be useful if user enters messages consecutively, and what the bot needs is just the last one.
+
+## Related examples
+
+* [with-ramda](../with-ramda)
+* [console-hello-world](../console-hello-world)

--- a/examples/with-rxjs/index.js
+++ b/examples/with-rxjs/index.js
@@ -1,0 +1,20 @@
+const { ConsoleBot, middleware } = require('bottender');
+const { handler: rxHandler } = require('rx-handler');
+const { from } = require('rxjs');
+const { debounceTime } = require('rxjs/operators');
+
+const bot = new ConsoleBot();
+
+const handler = rxHandler();
+const handlerOberverable = from(handler);
+
+bot.onEvent(middleware([handler]));
+
+bot.createRuntime();
+
+const handlerObserver = handlerOberverable.pipe(debounceTime(1000));
+
+handlerObserver.subscribe(async context => {
+  console.log(''); // log the message from bot to next line.
+  await context.sendText(`Your final message is "${context.event.text}"`);
+});

--- a/examples/with-rxjs/package.json
+++ b/examples/with-rxjs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "with-rxjs",
+  "version": "1.0.0",
+  "description": "Writing a simple bot without imperative conditional statements using Rx.js",
+  "main": "index.js",
+  "scripts": {
+    "dev": "nodemon index.js",
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "bottender": "latest",
+    "rx-handler": "^1.0.1",
+    "rxjs": "^6.2.2"
+  },
+  "devDependencies": {
+    "nodemon": "^1.11.0"
+  },
+  "keywords": [
+    "reactive programming"
+  ],
+  "author": "xxhomey19 <xxhomey19@gmail.com>",
+  "license": "MIT"
+}


### PR DESCRIPTION
Just try to put Bottender and RxJS together.

By using [debounceTime](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-debounceTime) from RxJS, console bot calls `context.sendText` only when user stops entering for one second.
Here is a screenshot of the result of this example.

![kapture 2018-08-26 at 21 45 44](https://user-images.githubusercontent.com/12113222/44627913-e735cd80-a979-11e8-9b11-dd33e4596846.gif)
