### PR TITLE
add reply_to_message to extend Telegram Message type

### DIFF
--- a/src/context/TelegramEvent.js
+++ b/src/context/TelegramEvent.js
@@ -96,6 +96,7 @@ type Message = {
     offset: number,
     length: number,
   }>,
+  reply_to_message?: Message,
   photo?: Photo,
   game?: Game,
   audio?: Audio,
@@ -225,6 +226,31 @@ export default class TelegramEvent implements Event {
   get text(): ?string {
     if (this.isText) {
       return (this.message: any).text;
+    }
+    return null;
+  }
+
+  /**
+   * Determine if the event which include reply to message.
+   *
+   */
+  get isReplyToMessage(): boolean {
+    if (!this.isMessage) return false;
+
+    const message: Message = (this.message: any);
+
+    return (
+      !!message.reply_to_message && typeof message.reply_to_message === 'object'
+    );
+  }
+
+  /**
+   * The Message object from Telegram raw event which includes reply_to_message.
+   *
+   */
+  get replyToMessage(): ?Message {
+    if (this.isReplyToMessage) {
+      return (this.message: any).reply_to_message;
     }
     return null;
   }

--- a/src/context/__tests__/TelegramEvent.spec.js
+++ b/src/context/__tests__/TelegramEvent.spec.js
@@ -548,6 +548,45 @@ const preCheckoutQuery = {
   },
 };
 
+const replyToTextMessage = {
+  message: {
+    message_id: 666,
+    from: {
+      id: 427770117,
+      is_bot: false,
+      first_name: 'first',
+      last_name: 'last',
+      language_code: 'en',
+    },
+    chat: {
+      id: 427770117,
+      first_name: 'first',
+      last_name: 'last',
+      type: 'private',
+    },
+    date: 1499402829,
+    text: 'replyText',
+    reply_to_message: {
+      message_id: 777,
+      from: {
+        id: 427770117,
+        is_bot: false,
+        first_name: 'first',
+        last_name: 'last',
+        language_code: 'en',
+      },
+      chat: {
+        id: 427770117,
+        first_name: 'first',
+        last_name: 'last',
+        type: 'private',
+      },
+      date: 1499402829,
+      text: 'text',
+    },
+  },
+};
+
 it('#rawEvent', () => {
   expect(new TelegramEvent(textMessage).rawEvent).toEqual(textMessage);
   expect(new TelegramEvent(editedMessage).rawEvent).toEqual(editedMessage);
@@ -564,6 +603,9 @@ it('#rawEvent', () => {
   expect(new TelegramEvent(preCheckoutQuery).rawEvent).toEqual(
     preCheckoutQuery
   );
+  expect(new TelegramEvent(replyToTextMessage).rawEvent).toEqual(
+    replyToTextMessage
+  );
 });
 
 it('#isMessage', () => {
@@ -577,6 +619,7 @@ it('#isMessage', () => {
   expect(new TelegramEvent(callbackQuery).isMessage).toEqual(false);
   expect(new TelegramEvent(shippingQuery).isMessage).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isMessage).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isMessage).toEqual(true);
 });
 
 it('#message', () => {
@@ -624,24 +667,107 @@ it('#message', () => {
   expect(new TelegramEvent(callbackQuery).message).toEqual(null);
   expect(new TelegramEvent(shippingQuery).message).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).message).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).message).toEqual({
+    message_id: 666,
+    from: {
+      id: 427770117,
+      is_bot: false,
+      first_name: 'first',
+      last_name: 'last',
+      language_code: 'en',
+    },
+    chat: {
+      id: 427770117,
+      first_name: 'first',
+      last_name: 'last',
+      type: 'private',
+    },
+    date: 1499402829,
+    text: 'replyText',
+    reply_to_message: {
+      message_id: 777,
+      from: {
+        id: 427770117,
+        is_bot: false,
+        first_name: 'first',
+        last_name: 'last',
+        language_code: 'en',
+      },
+      chat: {
+        id: 427770117,
+        first_name: 'first',
+        last_name: 'last',
+        type: 'private',
+      },
+      date: 1499402829,
+      text: 'text',
+    },
+  });
 });
 
 it('#isText', () => {
   expect(new TelegramEvent(callbackQuery).isText).toEqual(false);
   expect(new TelegramEvent(textMessage).isText).toEqual(true);
   expect(new TelegramEvent(stickerMessage).isText).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isText).toEqual(true);
 });
 
 it('#text', () => {
   expect(new TelegramEvent(callbackQuery).text).toEqual(null);
   expect(new TelegramEvent(textMessage).text).toEqual('text');
   expect(new TelegramEvent(stickerMessage).text).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).text).toEqual('replyText');
+});
+
+it('#isReplyToMessage', () => {
+  expect(new TelegramEvent(textMessage).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(groupMessage).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(editedMessage).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(channelPost).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(editedChannelPost).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(inlineQuery).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(chosenInlineResult).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(callbackQuery).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(shippingQuery).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(preCheckoutQuery).isReplyToMessage).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isReplyToMessage).toEqual(true);
+});
+
+it('#replyToMessage', () => {
+  expect(new TelegramEvent(textMessage).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(editedMessage).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(channelPost).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(editedChannelPost).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(inlineQuery).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(chosenInlineResult).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(callbackQuery).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(shippingQuery).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(preCheckoutQuery).replyToMessage).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).replyToMessage).toEqual({
+    message_id: 777,
+    from: {
+      id: 427770117,
+      is_bot: false,
+      first_name: 'first',
+      last_name: 'last',
+      language_code: 'en',
+    },
+    chat: {
+      id: 427770117,
+      first_name: 'first',
+      last_name: 'last',
+      type: 'private',
+    },
+    date: 1499402829,
+    text: 'text',
+  });
 });
 
 it('#isAudio', () => {
   expect(new TelegramEvent(callbackQuery).isAudio).toEqual(false);
   expect(new TelegramEvent(textMessage).isAudio).toEqual(false);
   expect(new TelegramEvent(audioMessage).isAudio).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isAudio).toEqual(false);
 });
 
 it('#audio', () => {
@@ -652,12 +778,14 @@ it('#audio', () => {
     duration: 100,
     title: 'audioooooooo',
   });
+  expect(new TelegramEvent(replyToTextMessage).audio).toEqual(null);
 });
 
 it('#isDocument', () => {
   expect(new TelegramEvent(callbackQuery).isDocument).toEqual(false);
   expect(new TelegramEvent(textMessage).isDocument).toEqual(false);
   expect(new TelegramEvent(documentMessage).isDocument).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isDocument).toEqual(false);
 });
 
 it('#document', () => {
@@ -667,12 +795,14 @@ it('#document', () => {
     file_id: '234',
     file_name: 'file',
   });
+  expect(new TelegramEvent(replyToTextMessage).document).toEqual(null);
 });
 
 it('#isGame', () => {
   expect(new TelegramEvent(callbackQuery).isGame).toEqual(false);
   expect(new TelegramEvent(textMessage).isGame).toEqual(false);
   expect(new TelegramEvent(gameMessage).isGame).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isGame).toEqual(false);
 });
 
 it('#game', () => {
@@ -694,12 +824,14 @@ it('#game', () => {
       },
     ],
   });
+  expect(new TelegramEvent(replyToTextMessage).game).toEqual(null);
 });
 
 it('#isPhoto', () => {
   expect(new TelegramEvent(callbackQuery).isPhoto).toEqual(false);
   expect(new TelegramEvent(textMessage).isPhoto).toEqual(false);
   expect(new TelegramEvent(photoMessage).isPhoto).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isPhoto).toEqual(false);
 });
 
 it('#photo', () => {
@@ -717,12 +849,14 @@ it('#photo', () => {
       height: 50,
     },
   ]);
+  expect(new TelegramEvent(replyToTextMessage).photo).toEqual(null);
 });
 
 it('#isSticker', () => {
   expect(new TelegramEvent(callbackQuery).isSticker).toEqual(false);
   expect(new TelegramEvent(textMessage).isSticker).toEqual(false);
   expect(new TelegramEvent(stickerMessage).isSticker).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isSticker).toEqual(false);
 });
 
 it('#sticker', () => {
@@ -733,12 +867,14 @@ it('#sticker', () => {
     width: 50,
     height: 50,
   });
+  expect(new TelegramEvent(replyToTextMessage).sticker).toEqual(null);
 });
 
 it('#isVideo', () => {
   expect(new TelegramEvent(callbackQuery).isVideo).toEqual(false);
   expect(new TelegramEvent(textMessage).isVideo).toEqual(false);
   expect(new TelegramEvent(videoMessage).isVideo).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isVideo).toEqual(false);
 });
 
 it('#video', () => {
@@ -750,12 +886,14 @@ it('#video', () => {
     height: 100,
     duration: 199,
   });
+  expect(new TelegramEvent(replyToTextMessage).video).toEqual(null);
 });
 
 it('#isVoice', () => {
   expect(new TelegramEvent(callbackQuery).isVoice).toEqual(false);
   expect(new TelegramEvent(textMessage).isVoice).toEqual(false);
   expect(new TelegramEvent(voiceMessage).isVoice).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isVoice).toEqual(false);
 });
 
 it('#voice', () => {
@@ -765,12 +903,14 @@ it('#voice', () => {
     file_id: '543',
     duration: 299,
   });
+  expect(new TelegramEvent(replyToTextMessage).voice).toEqual(null);
 });
 
 it('#isVideoNote', () => {
   expect(new TelegramEvent(callbackQuery).isVideoNote).toEqual(false);
   expect(new TelegramEvent(textMessage).isVideoNote).toEqual(false);
   expect(new TelegramEvent(videoNoteMessage).isVideoNote).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isVideoNote).toEqual(false);
 });
 
 it('#videoNote', () => {
@@ -781,12 +921,14 @@ it('#videoNote', () => {
     length: 100,
     duration: 399,
   });
+  expect(new TelegramEvent(replyToTextMessage).videoNote).toEqual(null);
 });
 
 it('#isContact', () => {
   expect(new TelegramEvent(callbackQuery).isContact).toEqual(false);
   expect(new TelegramEvent(textMessage).isContact).toEqual(false);
   expect(new TelegramEvent(contactMessage).isContact).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isContact).toEqual(false);
 });
 
 it('#contact', () => {
@@ -796,12 +938,14 @@ it('#contact', () => {
     phone_number: '123456789',
     first_name: 'first',
   });
+  expect(new TelegramEvent(replyToTextMessage).contact).toEqual(null);
 });
 
 it('#isLocation', () => {
   expect(new TelegramEvent(callbackQuery).isLocation).toEqual(false);
   expect(new TelegramEvent(textMessage).isLocation).toEqual(false);
   expect(new TelegramEvent(locationMessage).isLocation).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isLocation).toEqual(false);
 });
 
 it('#location', () => {
@@ -811,12 +955,14 @@ it('#location', () => {
     longitude: '111.111',
     latitude: '99.99',
   });
+  expect(new TelegramEvent(replyToTextMessage).location).toEqual(null);
 });
 
 it('#isVenue', () => {
   expect(new TelegramEvent(callbackQuery).isVenue).toEqual(false);
   expect(new TelegramEvent(textMessage).isVenue).toEqual(false);
   expect(new TelegramEvent(venueMessage).isVenue).toEqual(true);
+  expect(new TelegramEvent(replyToTextMessage).isVenue).toEqual(false);
 });
 
 it('#venue', () => {
@@ -830,6 +976,7 @@ it('#venue', () => {
     title: 'title',
     address: 'addressssss',
   });
+  expect(new TelegramEvent(replyToTextMessage).venue).toEqual(null);
 });
 
 it('#isEditedMessage', () => {
@@ -843,6 +990,7 @@ it('#isEditedMessage', () => {
   expect(new TelegramEvent(callbackQuery).isEditedMessage).toEqual(false);
   expect(new TelegramEvent(shippingQuery).isEditedMessage).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isEditedMessage).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isEditedMessage).toEqual(false);
 });
 
 it('#editedMessage', () => {
@@ -892,6 +1040,7 @@ it('#editedMessage', () => {
   expect(new TelegramEvent(callbackQuery).editedMessage).toEqual(null);
   expect(new TelegramEvent(shippingQuery).editedMessage).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).editedMessage).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).editedMessage).toEqual(null);
 });
 
 it('#isChannelPost', () => {
@@ -904,6 +1053,7 @@ it('#isChannelPost', () => {
   expect(new TelegramEvent(callbackQuery).isChannelPost).toEqual(false);
   expect(new TelegramEvent(shippingQuery).isChannelPost).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isChannelPost).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isChannelPost).toEqual(false);
 });
 
 it('#channelPost', () => {
@@ -925,6 +1075,7 @@ it('#channelPost', () => {
   expect(new TelegramEvent(callbackQuery).channelPost).toEqual(null);
   expect(new TelegramEvent(shippingQuery).channelPost).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).channelPost).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).channelPost).toEqual(null);
 });
 
 it('#isEditedChannelPost', () => {
@@ -941,6 +1092,9 @@ it('#isEditedChannelPost', () => {
   expect(new TelegramEvent(callbackQuery).isEditedChannelPost).toEqual(false);
   expect(new TelegramEvent(shippingQuery).isEditedChannelPost).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isEditedChannelPost).toEqual(
+    false
+  );
+  expect(new TelegramEvent(replyToTextMessage).isEditedChannelPost).toEqual(
     false
   );
 });
@@ -965,6 +1119,7 @@ it('#editedChannelPost', () => {
   expect(new TelegramEvent(callbackQuery).editedChannelPost).toEqual(null);
   expect(new TelegramEvent(shippingQuery).editedChannelPost).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).editedChannelPost).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).editedChannelPost).toEqual(null);
 });
 
 it('#isInlineQuery', () => {
@@ -977,6 +1132,7 @@ it('#isInlineQuery', () => {
   expect(new TelegramEvent(callbackQuery).isInlineQuery).toEqual(false);
   expect(new TelegramEvent(shippingQuery).isInlineQuery).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isInlineQuery).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isInlineQuery).toEqual(false);
 });
 
 it('#inlineQuery', () => {
@@ -1000,6 +1156,7 @@ it('#inlineQuery', () => {
   expect(new TelegramEvent(callbackQuery).inlineQuery).toEqual(null);
   expect(new TelegramEvent(shippingQuery).inlineQuery).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).inlineQuery).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).inlineQuery).toEqual(null);
 });
 
 it('#isChosenInlineResult', () => {
@@ -1016,6 +1173,9 @@ it('#isChosenInlineResult', () => {
   expect(new TelegramEvent(callbackQuery).isChosenInlineResult).toEqual(false);
   expect(new TelegramEvent(shippingQuery).isChosenInlineResult).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isChosenInlineResult).toEqual(
+    false
+  );
+  expect(new TelegramEvent(replyToTextMessage).isChosenInlineResult).toEqual(
     false
   );
 });
@@ -1041,6 +1201,9 @@ it('#chosenInlineResult', () => {
   expect(new TelegramEvent(callbackQuery).chosenInlineResult).toEqual(null);
   expect(new TelegramEvent(shippingQuery).chosenInlineResult).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).chosenInlineResult).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).chosenInlineResult).toEqual(
+    null
+  );
 });
 
 it('#isCallbackQuery', () => {
@@ -1054,6 +1217,7 @@ it('#isCallbackQuery', () => {
   expect(new TelegramEvent(groupCallbackQuery).isCallbackQuery).toEqual(true);
   expect(new TelegramEvent(shippingQuery).isCallbackQuery).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isCallbackQuery).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isCallbackQuery).toEqual(false);
 });
 
 it('#callbackQuery', () => {
@@ -1123,6 +1287,7 @@ it('#callbackQuery', () => {
   });
   expect(new TelegramEvent(shippingQuery).callbackQuery).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).callbackQuery).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).callbackQuery).toEqual(null);
 });
 
 it('#isPayload', () => {
@@ -1136,6 +1301,7 @@ it('#isPayload', () => {
   expect(new TelegramEvent(groupCallbackQuery).isPayload).toEqual(true);
   expect(new TelegramEvent(shippingQuery).isPayload).toEqual(false);
   expect(new TelegramEvent(preCheckoutQuery).isPayload).toEqual(false);
+  expect(new TelegramEvent(replyToTextMessage).isPayload).toEqual(false);
 });
 
 it('#payload', () => {
@@ -1149,4 +1315,5 @@ it('#payload', () => {
   expect(new TelegramEvent(groupCallbackQuery).payload).toEqual('123');
   expect(new TelegramEvent(shippingQuery).payload).toEqual(null);
   expect(new TelegramEvent(preCheckoutQuery).payload).toEqual(null);
+  expect(new TelegramEvent(replyToTextMessage).payload).toEqual(null);
 });


### PR DESCRIPTION
According to the Telegram Bot API document, message data will contain reply_to_message to get the original message when a user replies message.
https://core.telegram.org/bots/api#message

Although the message property in TelegramEvent still can get the reply_to_message, it should provide own property just like text, audio, sticker etc.

By rewrap as a TelegramEvent might be useful and can easily to determine the message type which replies. If replyToMessage return as a TelegramEvent object might break the original design, so it still not included in this PR now and can use this propose like this.

```javascript
const replyEvent = new TelegramEvent({
  update_id: context.event.rawEvent.update_id, // reply_to_message doesn't contain this.
  message: context.event.replyToMessage,
});

if (replyEvent.isText) {
 ...
}
```