### PR TITLE
fix ConsoleBot recognize symbol as _methodMissing

### DIFF
--- a/src/context/ConsoleContext.js
+++ b/src/context/ConsoleContext.js
@@ -19,6 +19,7 @@ type Options = {|
 |};
 
 const methodBlackList = [
+  'inspect', // console
   'then', // promise
   'handlerDidEnd', // context lifecycle
 ];
@@ -59,6 +60,9 @@ export default class ConsoleContext extends Context implements PlatformContext {
           }
 
           if (methodBlackList.includes(key)) return;
+          // $FlowIssue: Support `typeof x === "symbol"` - https://github.com/facebook/flow/issues/1015
+          if (typeof key === 'symbol') return; // any symbol should not be method missing
+
           return async (...args) => {
             await target._methodMissing(key, args);
           };

--- a/src/context/__tests__/ConsoleContext.spec.js
+++ b/src/context/__tests__/ConsoleContext.spec.js
@@ -1,3 +1,5 @@
+import util from 'util';
+
 jest.mock('delay');
 
 let ConsoleContext;
@@ -146,6 +148,13 @@ describe('method missing', () => {
 
     expect(context.handlerDidEnd).toBeUndefined();
     expect(context.then).toBeUndefined();
+    expect(context.inspect).toBeUndefined();
+  });
+
+  it('should not proxy symbol', async () => {
+    const { context } = setup({ fallbackMethods: true });
+
+    expect(context[util.inspect.custom]).toBeUndefined();
   });
 
   it('should not proxy falsy getters', async () => {


### PR DESCRIPTION
fix `ConsoleBot` recognize symbol as `_methodMissing`, for example, `Symbol('util.inspect.custom')`