### PR TITLE
platform bots: add origin option for testing purpose

### DIFF
--- a/src/bot/LineBot.js
+++ b/src/bot/LineBot.js
@@ -10,6 +10,7 @@ export default class LineBot extends Bot {
     accessToken,
     channelSecret,
     sessionStore,
+    origin,
     sync,
     shouldBatch,
     sendMethod,
@@ -20,12 +21,14 @@ export default class LineBot extends Bot {
     sync?: boolean,
     shouldBatch: ?boolean,
     sendMethod: ?string,
+    origin?: string,
   }) {
     const connector = new LineConnector({
       accessToken,
       channelSecret,
       shouldBatch,
       sendMethod,
+      origin,
     });
     super({ connector, sessionStore, sync });
   }

--- a/src/bot/LineConnector.js
+++ b/src/bot/LineConnector.js
@@ -21,6 +21,7 @@ type ConstructorOptions = {|
   client?: LineClient,
   shouldBatch: ?boolean,
   sendMethod: ?string,
+  origin?: string,
 |};
 
 export default class LineConnector implements Connector<LineRequestBody> {
@@ -38,8 +39,14 @@ export default class LineConnector implements Connector<LineRequestBody> {
     client,
     shouldBatch,
     sendMethod,
+    origin,
   }: ConstructorOptions) {
-    this._client = client || LineClient.connect(accessToken);
+    this._client =
+      client ||
+      LineClient.connect({
+        accessToken,
+        origin,
+      });
     this._channelSecret = channelSecret || '';
     this._shouldBatch = shouldBatch || false;
     warning(

--- a/src/bot/MessengerBot.js
+++ b/src/bot/MessengerBot.js
@@ -15,6 +15,7 @@ export default class MessengerBot extends Bot {
     mapPageToAccessToken,
     verifyToken,
     batchConfig,
+    origin,
   }: {
     accessToken: string,
     appId?: string,
@@ -24,6 +25,7 @@ export default class MessengerBot extends Bot {
     mapPageToAccessToken?: (pageId: string) => Promise<string>,
     verifyToken?: string,
     batchConfig?: Object,
+    origin?: string,
   }) {
     const connector = new MessengerConnector({
       accessToken,
@@ -32,6 +34,7 @@ export default class MessengerBot extends Bot {
       mapPageToAccessToken,
       verifyToken,
       batchConfig,
+      origin,
     });
     super({ connector, sessionStore, sync });
   }

--- a/src/bot/MessengerConnector.js
+++ b/src/bot/MessengerConnector.js
@@ -82,6 +82,7 @@ type ConstructorOptions = {|
   mapPageToAccessToken?: (pageId: string) => Promise<string>,
   verifyToken?: ?string,
   batchConfig?: ?Object,
+  origin?: string,
 |};
 
 export default class MessengerConnector
@@ -108,12 +109,14 @@ export default class MessengerConnector
     mapPageToAccessToken,
     verifyToken,
     batchConfig,
+    origin,
   }: ConstructorOptions) {
     this._client =
       client ||
       MessengerClient.connect({
         accessToken: accessToken || '',
         appSecret,
+        origin,
       });
 
     this._appId = appId || '';

--- a/src/bot/SlackBot.js
+++ b/src/bot/SlackBot.js
@@ -14,13 +14,19 @@ export default class SlackBot extends Bot {
     sessionStore,
     sync,
     verificationToken,
+    origin,
   }: {
     accessToken: string,
     sessionStore: SessionStore,
     sync?: boolean,
     verificationToken?: string,
+    origin?: string,
   }) {
-    const connector = new SlackConnector({ accessToken, verificationToken });
+    const connector = new SlackConnector({
+      accessToken,
+      verificationToken,
+      origin,
+    });
     super({ connector, sessionStore, sync });
     this._accessToken = accessToken;
   }

--- a/src/bot/SlackConnector.js
+++ b/src/bot/SlackConnector.js
@@ -38,6 +38,7 @@ type ConstructorOptions = {|
   accessToken?: string,
   client?: SlackOAuthClient,
   verificationToken?: string,
+  origin?: string,
 |};
 
 export default class SlackConnector implements Connector<SlackRequestBody> {
@@ -45,8 +46,18 @@ export default class SlackConnector implements Connector<SlackRequestBody> {
 
   _verificationToken: string;
 
-  constructor({ accessToken, client, verificationToken }: ConstructorOptions) {
-    this._client = client || SlackOAuthClient.connect(accessToken);
+  constructor({
+    accessToken,
+    client,
+    verificationToken,
+    origin,
+  }: ConstructorOptions) {
+    this._client =
+      client ||
+      SlackOAuthClient.connect({
+        accessToken,
+        origin,
+      });
     this._verificationToken = verificationToken || '';
 
     if (!this._verificationToken) {

--- a/src/bot/TelegramBot.js
+++ b/src/bot/TelegramBot.js
@@ -21,12 +21,14 @@ export default class TelegramBot extends Bot {
     accessToken,
     sessionStore,
     sync,
+    origin,
   }: {
     accessToken: string,
     sessionStore: SessionStore,
     sync?: boolean,
+    origin?: string,
   }) {
-    const connector = new TelegramConnector({ accessToken });
+    const connector = new TelegramConnector({ accessToken, origin });
     super({ connector, sessionStore, sync });
   }
 

--- a/src/bot/TelegramConnector.js
+++ b/src/bot/TelegramConnector.js
@@ -13,14 +13,20 @@ export type TelegramRequestBody = TelegramRawEvent;
 type ConstructorOptions = {|
   accessToken?: string,
   client?: TelegramClient,
+  origin?: string,
 |};
 
 export default class TelegramConnector
   implements Connector<TelegramRequestBody> {
   _client: TelegramClient;
 
-  constructor({ accessToken, client }: ConstructorOptions) {
-    this._client = client || TelegramClient.connect(accessToken);
+  constructor({ accessToken, client, origin }: ConstructorOptions) {
+    this._client =
+      client ||
+      TelegramClient.connect({
+        accessToken,
+        origin,
+      });
   }
 
   _getRawEventFromRequest(body: TelegramRequestBody): TelegramRawEvent {

--- a/src/bot/ViberBot.js
+++ b/src/bot/ViberBot.js
@@ -10,12 +10,14 @@ export default class ViberBot extends Bot {
     accessToken,
     sessionStore,
     sync,
+    origin,
   }: {
     accessToken: string,
     sessionStore: SessionStore,
     sync?: boolean,
+    origin?: string,
   }) {
-    const connector = new ViberConnector({ accessToken });
+    const connector = new ViberConnector({ accessToken, origin });
     super({ connector, sessionStore, sync });
   }
 }

--- a/src/bot/ViberConnector.js
+++ b/src/bot/ViberConnector.js
@@ -15,6 +15,7 @@ export type ViberRequestBody = ViberRawEvent;
 type ConstructorOptions = {|
   accessToken?: string,
   client?: ViberClient,
+  origin?: string,
 |};
 
 export default class ViberConnector implements Connector<ViberRequestBody> {
@@ -22,9 +23,14 @@ export default class ViberConnector implements Connector<ViberRequestBody> {
 
   _client: ViberClient;
 
-  constructor({ accessToken, client }: ConstructorOptions) {
+  constructor({ accessToken, client, origin }: ConstructorOptions) {
     this._accessToken = accessToken;
-    this._client = client || ViberClient.connect(accessToken);
+    this._client =
+      client ||
+      ViberClient.connect({
+        accessToken,
+        origin,
+      });
   }
 
   _getRawEventFromRequest(body: ViberRequestBody): ViberRawEvent {


### PR DESCRIPTION
Example:

```js
new MessengerBot({
  // ...
  origin: 'https://mydummytestserver.com',
});
new LineBot({
  // ...
  origin: 'https://mydummytestserver.com',
});
new SlackBot({
  // ...
  origin: 'https://mydummytestserver.com',
});
new ViberBot({
  // ...
  origin: 'https://mydummytestserver.com',
});
new TelegramBot({
  // ...
  origin: 'https://mydummytestserver.com',
});
```