### PR TITLE
fix bottender -h command missing arguments

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -19,7 +19,7 @@ const main = async _argv => {
     {
       '--version': Boolean,
       '-v': '--version',
-      '--help': String,
+      '--help': Boolean,
       '-h': '--help',
     },
     {


### PR DESCRIPTION
fix #357 