### PR TITLE
implement skipProfile for slack

### DIFF
--- a/src/bot/SlackBot.js
+++ b/src/bot/SlackBot.js
@@ -15,17 +15,20 @@ export default class SlackBot extends Bot {
     sync,
     verificationToken,
     origin,
+    skipProfile,
   }: {
     accessToken: string,
     sessionStore: SessionStore,
     sync?: boolean,
     verificationToken?: string,
     origin?: string,
+    skipProfile?: ?boolean,
   }) {
     const connector = new SlackConnector({
       accessToken,
       verificationToken,
       origin,
+      skipProfile,
     });
     super({ connector, sessionStore, sync });
     this._accessToken = accessToken;

--- a/src/bot/__tests__/SlackConnector.spec.js
+++ b/src/bot/__tests__/SlackConnector.spec.js
@@ -111,7 +111,7 @@ const RtmMessage = {
   team: 'T056KAAAA',
 };
 
-function setup({ verificationToken } = {}) {
+function setup({ verificationToken, skipProfile } = {}) {
   const mockSlackOAuthClient = {
     getUserInfo: jest.fn(),
     getConversationInfo: jest.fn(),
@@ -121,7 +121,11 @@ function setup({ verificationToken } = {}) {
   SlackOAuthClient.connect = jest.fn();
   SlackOAuthClient.connect.mockReturnValue(mockSlackOAuthClient);
   return {
-    connector: new SlackConnector({ accessToken, verificationToken }),
+    connector: new SlackConnector({
+      accessToken,
+      verificationToken,
+      skipProfile,
+    }),
     mockSlackOAuthClient,
   };
 }
@@ -304,6 +308,29 @@ describe('#updateSession', () => {
         ...channel,
       },
       team: { members, _updatedAt: expect.any(String) },
+    });
+  });
+
+  it('update session without calling apis while skipProfile setted true', async () => {
+    const { connector, mockSlackOAuthClient } = setup({ skipProfile: true });
+
+    const session = {};
+
+    await connector.updateSession(session, request.body);
+
+    expect(mockSlackOAuthClient.getUserInfo).not.toBeCalled();
+    expect(mockSlackOAuthClient.getConversationInfo).not.toBeCalled();
+    expect(mockSlackOAuthClient.getAllConversationMembers).not.toBeCalled();
+    expect(mockSlackOAuthClient.getAllUserList).not.toBeCalled();
+    expect(session).toEqual({
+      user: {
+        _updatedAt: expect.any(String),
+        id: 'U13A00000',
+      },
+      channel: {
+        _updatedAt: expect.any(String),
+        id: 'C6A900000',
+      },
     });
   });
 });


### PR DESCRIPTION
If the user profile is not necessary in the bot responding logic, we can skip the profile updating and have a better responding experience.

With this flag setted true, skiping all the getUserProfile api calls when session updating, providing better performance when dealing heavy traffic.