### PR TITLE
implement map destination to events

### DIFF
--- a/src/bot/LineConnector.js
+++ b/src/bot/LineConnector.js
@@ -12,6 +12,7 @@ import { type Session } from '../session/Session';
 import { type Connector } from './Connector';
 
 type LineRequestBody = {
+  destination: string,
   events: Array<LineRawEvent>,
 };
 
@@ -244,9 +245,11 @@ export default class LineConnector implements Connector<LineRequestBody> {
   }
 
   mapRequestToEvents(body: LineRequestBody): Array<LineEvent> {
+    const { destination } = body;
+
     return body.events
-      .filter(e => !this._isWebhookVerifyEvent(e))
-      .map(e => new LineEvent(e));
+      .filter(event => !this._isWebhookVerifyEvent(event))
+      .map(event => new LineEvent(event, { destination }));
   }
 
   createContext(params: {

--- a/src/bot/__tests__/LineConnector.spec.js
+++ b/src/bot/__tests__/LineConnector.spec.js
@@ -13,6 +13,7 @@ const CHANNEL_SECRET = 'FAKE_SECRET';
 
 const request = {
   body: {
+    destination: 'Uea8667adaf43586706170ff25ff47ae6',
     events: [
       {
         replyToken: 'nHuyWiB7yP5Zw52FIkcQobQuGDXCTA',
@@ -607,6 +608,8 @@ describe('#mapRequestToEvents', () => {
     expect(events).toHaveLength(2);
     expect(events[0]).toBeInstanceOf(LineEvent);
     expect(events[1]).toBeInstanceOf(LineEvent);
+    expect(events[0].destination).toBe('Uea8667adaf43586706170ff25ff47ae6');
+    expect(events[1].destination).toBe('Uea8667adaf43586706170ff25ff47ae6');
   });
 
   it('should map webhook verify request to empty array', () => {

--- a/src/context/LineEvent.js
+++ b/src/context/LineEvent.js
@@ -60,6 +60,10 @@ type AccountLink = {|
   nonce: string,
 |};
 
+type LineEventOptions = {
+  destination?: ?string,
+};
+
 export type LineRawEvent = {
   // only message, follow, join, postback, beacon, accountLink events have replyToken
   replyToken?: ReplyToken,
@@ -75,8 +79,11 @@ export type LineRawEvent = {
 export default class LineEvent implements Event {
   _rawEvent: LineRawEvent;
 
-  constructor(rawEvent: LineRawEvent) {
+  _destination: ?string;
+
+  constructor(rawEvent: LineRawEvent, options: LineEventOptions = {}) {
     this._rawEvent = rawEvent;
+    this._destination = options.destination;
   }
 
   /**
@@ -85,6 +92,14 @@ export default class LineEvent implements Event {
    */
   get rawEvent(): LineRawEvent {
     return this._rawEvent;
+  }
+
+  /**
+   * The destination is the id of the bot which this event is sent to.
+   *
+   */
+  get destination(): ?string {
+    return this._destination || null;
   }
 
   /**

--- a/src/context/__tests__/LineEvent.spec.js
+++ b/src/context/__tests__/LineEvent.spec.js
@@ -220,6 +220,8 @@ const accountLink = {
 
 const noSourceMessage = {};
 
+const destination = 'Uea8667adaf43586706170ff25ff47ae6';
+
 it('#rawEvent', () => {
   expect(new LineEvent(textMessage).rawEvent).toEqual(textMessage);
   expect(new LineEvent(imageMessage).rawEvent).toEqual(imageMessage);
@@ -233,6 +235,46 @@ it('#rawEvent', () => {
   expect(new LineEvent(leave).rawEvent).toEqual(leave);
   expect(new LineEvent(postback).rawEvent).toEqual(postback);
   expect(new LineEvent(beacon).rawEvent).toEqual(beacon);
+});
+
+it('#destination', () => {
+  expect(new LineEvent(textMessage, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(imageMessage, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(videoMessage, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(audioMessage, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(locationMessage, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(stickerMessage, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(follow, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(unfollow, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(join, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(leave, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(postback, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(beacon, { destination }).destination).toEqual(
+    'Uea8667adaf43586706170ff25ff47ae6'
+  );
+  expect(new LineEvent(textMessage).destination).toEqual(null);
 });
 
 it('#replyToken', () => {


### PR DESCRIPTION
In order to get destination when creating context, we have to map the destination (which sent in the body) to every events.