### PR TITLE
add page into messenger session

### DIFF
--- a/src/bot/MessengerConnector.js
+++ b/src/bot/MessengerConnector.js
@@ -246,17 +246,20 @@ export default class MessengerConnector
     if (!session.user || this._profilePicExpired(session.user)) {
       const senderId = this.getUniqueSessionKey(body);
 
+      const rawEvent = this._getRawEventsFromRequest(body)[0];
+      const pageId = this._getPageIdFromRawEvent(rawEvent);
       let customAccessToken;
-      if (this._mapPageToAccessToken != null) {
-        const mapPageToAccessToken = this._mapPageToAccessToken;
 
-        const rawEvent = this._getRawEventsFromRequest(body)[0];
+      if (!pageId) {
+        warning(false, 'Could not find pageId from request body.');
+      } else {
+        session.page = {
+          id: pageId,
+          _updatedAt: new Date().toISOString(),
+        };
 
-        const pageId = this._getPageIdFromRawEvent(rawEvent);
-
-        if (!pageId) {
-          warning(false, 'Could not find pageId from request body.');
-        } else {
+        if (this._mapPageToAccessToken != null) {
+          const mapPageToAccessToken = this._mapPageToAccessToken;
           customAccessToken = await mapPageToAccessToken(pageId);
         }
       }
@@ -300,6 +303,14 @@ export default class MessengerConnector
       enumerable: true,
       writable: false,
       value: session.user,
+    });
+
+    Object.freeze(session.page);
+    Object.defineProperty(session, 'page', {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: session.page,
     });
   }
 

--- a/src/bot/__tests__/MessengerConnector.spec.js
+++ b/src/bot/__tests__/MessengerConnector.spec.js
@@ -297,6 +297,10 @@ describe('#updateSession', () => {
       { access_token: undefined }
     );
     expect(session).toEqual({
+      page: {
+        _updatedAt: expect.any(String),
+        id: '1895382890692545',
+      },
       user: {
         _updatedAt: expect.any(String),
         ...user,
@@ -329,6 +333,10 @@ describe('#updateSession', () => {
       { access_token: undefined }
     );
     expect(session).toEqual({
+      page: {
+        _updatedAt: expect.any(String),
+        id: '1895382890692545',
+      },
       user: {
         _updatedAt: expect.any(String),
         ...user,
@@ -361,6 +369,10 @@ describe('#updateSession', () => {
       { access_token: undefined }
     );
     expect(session).toEqual({
+      page: {
+        _updatedAt: expect.any(String),
+        id: '1895382890692545',
+      },
       user: {
         _updatedAt: expect.any(String),
         ...user,
@@ -393,6 +405,10 @@ describe('#updateSession', () => {
       { access_token: undefined }
     );
     expect(session).toEqual({
+      page: {
+        _updatedAt: expect.any(String),
+        id: '1895382890692545',
+      },
       user: {
         _updatedAt: expect.any(String),
         ...user,
@@ -414,6 +430,10 @@ describe('#updateSession', () => {
       { access_token: undefined }
     );
     expect(session).toEqual({
+      page: {
+        _updatedAt: expect.any(String),
+        id: '1895382890692545',
+      },
       user: {
         _updatedAt: expect.any(String),
         id: '1412611362105802',
@@ -436,6 +456,10 @@ describe('#updateSession', () => {
 
     expect(mockGraphAPIClient.getUserProfile).not.toBeCalled();
     expect(session).toEqual({
+      page: {
+        _updatedAt: expect.any(String),
+        id: '1895382890692545',
+      },
       user: {
         _updatedAt: expect.any(String),
         id: '1412611362105802',


### PR DESCRIPTION
In order to identify which facebook page was this session happen on, we need to add at least id into the sessions.