### PR TITLE
pass requestContext to getUniqueSessionKey as second argument

### DIFF
--- a/src/bot/Bot.js
+++ b/src/bot/Bot.js
@@ -112,7 +112,10 @@ export default class Bot {
       }
 
       const { platform } = this._connector;
-      const sessionKey = this._connector.getUniqueSessionKey(body);
+      const sessionKey = this._connector.getUniqueSessionKey(
+        body,
+        requestContext
+      );
 
       // Create or retrieve session if possible
       let sessionId;

--- a/src/bot/Connector.js
+++ b/src/bot/Connector.js
@@ -4,7 +4,7 @@ import { type Session } from '../session/Session';
 
 export interface Connector<B> {
   +platform: string;
-  getUniqueSessionKey(body: B): ?string;
+  getUniqueSessionKey(body: B, requestContext?: ?Object): ?string;
   updateSession(session: Session, body: B): Promise<void>;
   mapRequestToEvents(body: B): Array<any>;
   createContext(params: {


### PR DESCRIPTION
It gives a chance to get session key from any information in request context (path, header, params...).