### PR TITLE
remove useless afterEaches in tests

### DIFF
--- a/src/bot/__tests__/Bot.spec.js
+++ b/src/bot/__tests__/Bot.spec.js
@@ -29,14 +29,8 @@ function setup({
   };
 }
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 describe('#connector', () => {

--- a/src/bot/__tests__/ConsoleConnector.spec.js
+++ b/src/bot/__tests__/ConsoleConnector.spec.js
@@ -41,14 +41,8 @@ describe('#client', () => {
   });
 
   describe('#sendText', () => {
-    let _write;
     beforeEach(() => {
-      _write = process.stdout.write;
       process.stdout.write = jest.fn();
-    });
-
-    afterEach(() => {
-      process.stdout.write = _write;
     });
 
     it('should call stdout', () => {

--- a/src/bot/__tests__/MessengerBot.spec.js
+++ b/src/bot/__tests__/MessengerBot.spec.js
@@ -1,14 +1,8 @@
 import MessengerBot from '../MessengerBot';
 import MessengerConnector from '../MessengerConnector';
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should construct bot with MessengerConnector', () => {

--- a/src/bot/__tests__/MessengerConnector.spec.js
+++ b/src/bot/__tests__/MessengerConnector.spec.js
@@ -189,14 +189,8 @@ function setup(
   };
 }
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should use accessToken and appSecret (for appsecret_proof) to create default client', () => {

--- a/src/bot/__tests__/SlackBot.spec.js
+++ b/src/bot/__tests__/SlackBot.spec.js
@@ -5,14 +5,8 @@ import SlackConnector from '../SlackConnector';
 
 jest.mock('@slack/client');
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should construct bot with SlackConnector', () => {

--- a/src/bot/__tests__/TelegramBot.spec.js
+++ b/src/bot/__tests__/TelegramBot.spec.js
@@ -11,14 +11,8 @@ jest.mock('messaging-api-telegram', () => {
   };
 });
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should construct bot with TelegramConnector', () => {

--- a/src/cli/providers/messenger/__tests__/deleteMessengerProfile.spec.js
+++ b/src/cli/providers/messenger/__tests__/deleteMessengerProfile.spec.js
@@ -17,7 +17,6 @@ const MOCK_FILE_WITH_PLATFORM = {
 };
 
 let _client;
-const _exit = process.exit;
 
 beforeEach(() => {
   process.exit = jest.fn();
@@ -28,10 +27,6 @@ beforeEach(() => {
   log.error = jest.fn();
   log.print = jest.fn();
   getConfig.mockReturnValue(MOCK_FILE_WITH_PLATFORM.messenger);
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/messenger/__tests__/getPersistentMenu.spec.js
+++ b/src/cli/providers/messenger/__tests__/getPersistentMenu.spec.js
@@ -17,7 +17,6 @@ const MOCK_FILE_WITH_PLATFORM = {
 };
 
 let _client;
-const _consoleLog = console.log;
 
 beforeEach(() => {
   _client = {
@@ -28,10 +27,6 @@ beforeEach(() => {
   log.print = jest.fn();
   console.log = jest.fn();
   getConfig.mockReturnValue(MOCK_FILE_WITH_PLATFORM.messenger);
-});
-
-afterEach(() => {
-  console.log = _consoleLog;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/messenger/__tests__/help.spec.js
+++ b/src/cli/providers/messenger/__tests__/help.spec.js
@@ -1,14 +1,8 @@
 import help from '../help';
 
-const consoleLog = console.log;
-
 describe('help', () => {
   beforeEach(() => {
     console.log = jest.fn();
-  });
-
-  afterEach(() => {
-    console.log = consoleLog;
   });
 
   it('shouild exist', () => {

--- a/src/cli/providers/messenger/__tests__/listPersona.spec.js
+++ b/src/cli/providers/messenger/__tests__/listPersona.spec.js
@@ -17,7 +17,6 @@ const MOCK_FILE_WITH_PLATFORM = {
 };
 
 let _client;
-const _consoleLog = console.log;
 
 beforeEach(() => {
   _client = {
@@ -28,10 +27,6 @@ beforeEach(() => {
   log.print = jest.fn();
   console.log = jest.fn();
   getConfig.mockReturnValue(MOCK_FILE_WITH_PLATFORM.messenger);
-});
-
-afterEach(() => {
-  console.log = _consoleLog;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/messenger/__tests__/setMessengerProfile.spec.js
+++ b/src/cli/providers/messenger/__tests__/setMessengerProfile.spec.js
@@ -36,7 +36,6 @@ const MOCK_FILE_WITH_PLATFORM = {
 };
 
 let _client;
-const _exit = process.exit;
 
 beforeEach(() => {
   process.NODE_ENV = 'test';
@@ -65,10 +64,6 @@ beforeEach(() => {
   ]);
   MessengerClient.connect = jest.fn(() => _client);
   getConfig.mockReturnValue(MOCK_FILE_WITH_PLATFORM.messenger);
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/sh/__tests__/help.spec.js
+++ b/src/cli/providers/sh/__tests__/help.spec.js
@@ -1,14 +1,8 @@
 import help from '../help';
 
-const consoleLog = console.log;
-
 describe('help', () => {
   beforeEach(() => {
     console.log = jest.fn();
-  });
-
-  afterEach(() => {
-    console.log = consoleLog;
   });
 
   it('shouild exist', () => {

--- a/src/cli/providers/telegram/__tests__/deleteWebhook.spec.js
+++ b/src/cli/providers/telegram/__tests__/deleteWebhook.spec.js
@@ -9,7 +9,6 @@ const { TelegramClient } = require('messaging-api-telegram');
 const log = require('../../../shared/log');
 const getConfig = require('../../../shared/getConfig');
 
-const _exit = process.exit;
 const MOCK_FILE_WITH_PLATFORM = {
   telegram: {
     accessToken: '__accessToken__',
@@ -24,10 +23,6 @@ beforeEach(() => {
   TelegramClient.connect.mockReturnValue({
     deleteWebhook: jest.fn().mockResolvedValue(true),
   });
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/telegram/__tests__/getWebhook.spec.js
+++ b/src/cli/providers/telegram/__tests__/getWebhook.spec.js
@@ -9,7 +9,6 @@ const { TelegramClient } = require('messaging-api-telegram');
 const log = require('../../../shared/log');
 const getConfig = require('../../../shared/getConfig');
 
-const _exit = process.exit;
 const MOCK_FILE_WITH_PLATFORM = {
   telegram: {
     accessToken: '__accessToken__',
@@ -29,10 +28,6 @@ beforeEach(() => {
       max_connections: 40,
     }),
   });
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/telegram/__tests__/help.spec.js
+++ b/src/cli/providers/telegram/__tests__/help.spec.js
@@ -1,14 +1,8 @@
 import help from '../help';
 
-const consoleLog = console.log;
-
 describe('help', () => {
   beforeEach(() => {
     console.log = jest.fn();
-  });
-
-  afterEach(() => {
-    console.log = consoleLog;
   });
 
   it('shouild exist', () => {

--- a/src/cli/providers/telegram/__tests__/setWebhook.spec.js
+++ b/src/cli/providers/telegram/__tests__/setWebhook.spec.js
@@ -21,7 +21,6 @@ const MOCK_FILE_WITH_PLATFORM = {
   },
   line: {},
 };
-const _exit = process.exit;
 
 const setup = (
   { webhook = undefined, ngrokPort = undefined, token = undefined } = {
@@ -50,10 +49,6 @@ beforeEach(() => {
   TelegramClient.connect.mockReturnValue({
     setWebhook: jest.fn().mockResolvedValue(true),
   });
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/viber/__tests__/deleteWebhook.spec.js
+++ b/src/cli/providers/viber/__tests__/deleteWebhook.spec.js
@@ -9,7 +9,6 @@ const { ViberClient } = require('messaging-api-viber');
 const log = require('../../../shared/log');
 const getConfig = require('../../../shared/getConfig');
 
-const _exit = process.exit;
 const MOCK_FILE_WITH_PLATFORM = {
   viber: {
     accessToken: '__accessToken__',
@@ -26,10 +25,6 @@ beforeEach(() => {
       status_message: 'ok',
     })),
   });
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/providers/viber/__tests__/help.spec.js
+++ b/src/cli/providers/viber/__tests__/help.spec.js
@@ -1,14 +1,8 @@
 import help from '../help';
 
-const consoleLog = console.log;
-
 describe('help', () => {
   beforeEach(() => {
     console.log = jest.fn();
-  });
-
-  afterEach(() => {
-    console.log = consoleLog;
   });
 
   it('shouild exist', () => {

--- a/src/cli/providers/viber/__tests__/setWebhook.spec.js
+++ b/src/cli/providers/viber/__tests__/setWebhook.spec.js
@@ -20,7 +20,6 @@ const MOCK_FILE_WITH_PLATFORM = {
     accessToken: '__accessToken__',
   },
 };
-const _exit = process.exit;
 
 const setup = (
   {
@@ -62,10 +61,6 @@ beforeEach(() => {
       ],
     })),
   });
-});
-
-afterEach(() => {
-  process.exit = _exit;
 });
 
 it('be defined', () => {

--- a/src/cli/shared/__tests__/log.spec.js
+++ b/src/cli/shared/__tests__/log.spec.js
@@ -4,14 +4,9 @@ import figures from 'figures';
 
 import { bold, error, log, print, warn } from '../log';
 
-const _log = console.log;
-
 describe('console', () => {
   beforeEach(() => {
     console.log = jest.fn();
-  });
-  afterEach(() => {
-    console.log = _log;
   });
 
   it('log', () => {

--- a/src/context/__tests__/ConsoleContext.spec.js
+++ b/src/context/__tests__/ConsoleContext.spec.js
@@ -14,10 +14,6 @@ beforeEach(() => {
   /* eslint-enable global-require */
 });
 
-afterEach(() => {
-  jest.useFakeTimers();
-});
-
 const rawEvent = {
   message: {
     text: 'Hello, world',

--- a/src/context/__tests__/MessengerContext-send.spec.js
+++ b/src/context/__tests__/MessengerContext-send.spec.js
@@ -20,10 +20,6 @@ beforeEach(() => {
   /* eslint-enable global-require */
 });
 
-afterEach(() => {
-  jest.useFakeTimers();
-});
-
 const _rawEvent = {
   sender: { id: '1423587017700273' },
   recipient: { id: '404217156637689' },

--- a/src/context/__tests__/MessengerContext-sendTemplate.spec.js
+++ b/src/context/__tests__/MessengerContext-sendTemplate.spec.js
@@ -18,10 +18,6 @@ beforeEach(() => {
   /* eslint-enable global-require */
 });
 
-afterEach(() => {
-  jest.useFakeTimers();
-});
-
 const _rawEvent = {
   sender: { id: '1423587017700273' },
   recipient: { id: '404217156637689' },

--- a/src/context/__tests__/MessengerContext.spec.js
+++ b/src/context/__tests__/MessengerContext.spec.js
@@ -16,10 +16,6 @@ beforeEach(() => {
   /* eslint-enable global-require */
 });
 
-afterEach(() => {
-  jest.useFakeTimers();
-});
-
 const APP_ID = '1234567890';
 const PERSONA_ID = '987654321';
 

--- a/src/context/__tests__/TestContext.spec.js
+++ b/src/context/__tests__/TestContext.spec.js
@@ -12,10 +12,6 @@ beforeEach(() => {
   /* eslint-enable global-require */
 });
 
-afterEach(() => {
-  jest.useFakeTimers();
-});
-
 const rawEvent = {
   message: {
     text: 'Hello, world',

--- a/src/express/__tests__/createServer.spec.js
+++ b/src/express/__tests__/createServer.spec.js
@@ -20,14 +20,8 @@ function setup({ platform }) {
   };
 }
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should handle token verification', async () => {

--- a/src/express/__tests__/verifyLineSignature.spec.js
+++ b/src/express/__tests__/verifyLineSignature.spec.js
@@ -21,14 +21,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/express/__tests__/verifyMessengerSignature.spec.js
+++ b/src/express/__tests__/verifyMessengerSignature.spec.js
@@ -21,14 +21,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/express/__tests__/verifyMessengerWebhook.spec.js
+++ b/src/express/__tests__/verifyMessengerWebhook.spec.js
@@ -18,14 +18,8 @@ const createReqRes = ({ verifyToken }) => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should correctly response the challenge when verifyToken is same', () => {

--- a/src/express/__tests__/verifySlackSignature.spec.js
+++ b/src/express/__tests__/verifySlackSignature.spec.js
@@ -18,14 +18,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/express/__tests__/verifyViberSignature.spec.js
+++ b/src/express/__tests__/verifyViberSignature.spec.js
@@ -21,14 +21,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/koa/__tests__/createServer.spec.js
+++ b/src/koa/__tests__/createServer.spec.js
@@ -20,14 +20,8 @@ function setup({ platform }) {
   };
 }
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should handle token verification', async () => {

--- a/src/koa/__tests__/verifyLineSignature.spec.js
+++ b/src/koa/__tests__/verifyLineSignature.spec.js
@@ -18,14 +18,8 @@ const createContext = () => ({
   response: {},
 });
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/koa/__tests__/verifyMessengerSignature.spec.js
+++ b/src/koa/__tests__/verifyMessengerSignature.spec.js
@@ -18,14 +18,8 @@ const createContext = () => ({
   response: {},
 });
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/koa/__tests__/verifyMessengerWebhook.spec.js
+++ b/src/koa/__tests__/verifyMessengerWebhook.spec.js
@@ -15,14 +15,8 @@ const createContext = ({ verifyToken }) => ({
   response: {},
 });
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should correctly response the challenge when verifyToken is same', () => {

--- a/src/koa/__tests__/verifySlackSignature.spec.js
+++ b/src/koa/__tests__/verifySlackSignature.spec.js
@@ -15,14 +15,8 @@ const createContext = () => ({
   response: {},
 });
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/koa/__tests__/verifyViberSignature.spec.js
+++ b/src/koa/__tests__/verifyViberSignature.spec.js
@@ -18,14 +18,8 @@ const createContext = () => ({
   response: {},
 });
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/micro/__tests__/createServer.spec.js
+++ b/src/micro/__tests__/createServer.spec.js
@@ -22,15 +22,9 @@ function setup({ platform, verifyToken }) {
   };
 }
 
-const _consoleLog = console.log;
-
 beforeEach(() => {
   console.log = jest.fn();
   connectNgrok.mockImplementation((arg, fn) => fn('error', 'localhost:1234'));
-});
-
-afterEach(() => {
-  console.log = _consoleLog;
 });
 
 it('should handle token verification', async () => {

--- a/src/micro/__tests__/verifyMessengerWebhook.spec.js
+++ b/src/micro/__tests__/verifyMessengerWebhook.spec.js
@@ -18,14 +18,8 @@ const createReqRes = ({ verifyToken }) => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should correctly response the challenge when verifyToken is same', () => {

--- a/src/restify/__tests__/createServer.spec.js
+++ b/src/restify/__tests__/createServer.spec.js
@@ -22,9 +22,6 @@ function setup({ platform }) {
   };
 }
 
-const _consoleLog = console.log;
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.log = jest.fn();
   console.error = jest.fn();
@@ -34,8 +31,6 @@ afterEach(() => {
   // restify did some dirty things to IncomingMessage.prototype so we delete it
   // https://github.com/restify/node-restify/blob/1430644b53b08051066e8d1798a90a18527d541d/lib/request.js#L261-L273
   delete IncomingMessage.prototype.query;
-  console.log = _consoleLog;
-  console.error = _consoleError;
 });
 
 it('should handle token verification', async () => {

--- a/src/restify/__tests__/verifyLineSignature.spec.js
+++ b/src/restify/__tests__/verifyLineSignature.spec.js
@@ -21,14 +21,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/restify/__tests__/verifyMessengerSignature.spec.js
+++ b/src/restify/__tests__/verifyMessengerSignature.spec.js
@@ -21,14 +21,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/restify/__tests__/verifyMessengerWebhook.spec.js
+++ b/src/restify/__tests__/verifyMessengerWebhook.spec.js
@@ -18,14 +18,8 @@ const createReqRes = ({ verifyToken }) => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should correctly response the challenge when verifyToken is same', () => {

--- a/src/restify/__tests__/verifySlackSignature.spec.js
+++ b/src/restify/__tests__/verifySlackSignature.spec.js
@@ -18,14 +18,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {

--- a/src/restify/__tests__/verifyViberSignature.spec.js
+++ b/src/restify/__tests__/verifyViberSignature.spec.js
@@ -21,14 +21,8 @@ const createReqRes = () => [
   },
 ];
 
-const _consoleError = console.error;
-
 beforeEach(() => {
   console.error = jest.fn();
-});
-
-afterEach(() => {
-  console.error = _consoleError;
 });
 
 it('should call next when verification pass', () => {


### PR DESCRIPTION
Our jest config:

```js
{
  "resetModules": true,
  "resetMocks": true
}
```

So we can clean up those `afterEach`.