### PR TITLE
[LINE] context.send to call sendMethod conditionally

### DIFF
--- a/src/context/LineContext.js
+++ b/src/context/LineContext.js
@@ -499,7 +499,7 @@ types.forEach(({ name, arity, aliases }) => {
 });
 
 types
-  .filter(({ name }) => name !== 'Text' && name !== '')
+  .filter(({ name }) => name !== 'Text')
   .forEach(({ name, aliases }) => {
     [name].concat(aliases || []).forEach(type => {
       Object.defineProperty(LineContext.prototype, `send${type}`, {

--- a/src/context/__tests__/LineContext.spec.js
+++ b/src/context/__tests__/LineContext.spec.js
@@ -420,10 +420,58 @@ describe('#pushText', () => {
 
 describe('send APIs', () => {
   describe('#send', () => {
-    it('is not defined', () => {
+    it('should call client.push', async () => {
+      const { context, client, session } = setup();
+
+      await context.send([Line.createText('2'), Line.createText('3')]);
+
+      expect(client.push).toBeCalledWith(
+        session.user.id,
+        [Line.createText('2'), Line.createText('3')],
+        {
+          accessToken: undefined,
+        }
+      );
+    });
+
+    it('should work with room session', async () => {
+      const { context, client, session } = setup({
+        session: roomSession,
+      });
+
+      await context.send([Line.createText('2'), Line.createText('3')]);
+
+      expect(client.push).toBeCalledWith(
+        session.room.id,
+        [Line.createText('2'), Line.createText('3')],
+        {
+          accessToken: undefined,
+        }
+      );
+    });
+
+    it('should work with group session', async () => {
+      const { context, client, session } = setup({
+        session: groupSession,
+      });
+
+      await context.send([Line.createText('2'), Line.createText('3')]);
+
+      expect(client.push).toBeCalledWith(
+        session.group.id,
+        [Line.createText('2'), Line.createText('3')],
+        {
+          accessToken: undefined,
+        }
+      );
+    });
+
+    it('should mark context as handled', async () => {
       const { context } = setup();
 
-      expect(context.send).not.toBeDefined();
+      await context.send([Line.createText('2'), Line.createText('3')]);
+
+      expect(context.isHandled).toBe(true);
     });
   });
 


### PR DESCRIPTION
Add `context.send` (reply, push) to consistent with `context.sendText` (replyText, pushText).
Eventually, we may rename `context.send` to `context.sendMessages`, `context.reply` to `context.replyMessages` and `context.push` to `context.pushMessages`.