### PR TITLE
[LINE] add onWebhookVerify callback support

### DIFF
--- a/src/bot/LineBot.js
+++ b/src/bot/LineBot.js
@@ -16,6 +16,7 @@ export default class LineBot extends Bot {
     shouldBatch,
     sendMethod,
     skipProfile,
+    onWebhookVerify,
   }: {
     accessToken: string,
     channelSecret: string,
@@ -26,6 +27,7 @@ export default class LineBot extends Bot {
     sendMethod: ?string,
     origin?: string,
     skipProfile?: ?boolean,
+    onWebhookVerify?: ?(httpContext: Object) => void,
   }) {
     const connector = new LineConnector({
       accessToken,
@@ -35,6 +37,7 @@ export default class LineBot extends Bot {
       sendMethod,
       origin,
       skipProfile,
+      onWebhookVerify,
     });
     super({ connector, sessionStore, sync });
   }

--- a/src/bot/LineConnector.js
+++ b/src/bot/LineConnector.js
@@ -26,6 +26,7 @@ type ConstructorOptions = {|
   sendMethod: ?string,
   origin?: string,
   skipProfile?: ?boolean,
+  onWebhookVerify?: ?(httpContext: Object) => void,
 |};
 
 export default class LineConnector implements Connector<LineRequestBody> {
@@ -41,6 +42,8 @@ export default class LineConnector implements Connector<LineRequestBody> {
 
   _sendMethod: ?string;
 
+  _onWebhookVerify: ?(httpContext: Object) => void;
+
   constructor({
     accessToken,
     channelSecret,
@@ -50,6 +53,7 @@ export default class LineConnector implements Connector<LineRequestBody> {
     sendMethod,
     origin,
     skipProfile,
+    onWebhookVerify,
   }: ConstructorOptions) {
     this._client =
       client ||
@@ -70,6 +74,12 @@ export default class LineConnector implements Connector<LineRequestBody> {
 
     // FIXME: maybe set this default value as true
     this._skipProfile = typeof skipProfile === 'boolean' ? skipProfile : false;
+
+    this._onWebhookVerify = onWebhookVerify;
+  }
+
+  get onWebhookVerify() {
+    return this._onWebhookVerify;
   }
 
   _isWebhookVerifyEvent(event: LineRawEvent): boolean {

--- a/src/bot/__tests__/LineConnector.spec.js
+++ b/src/bot/__tests__/LineConnector.spec.js
@@ -82,7 +82,7 @@ const webhookVerifyRequest = {
   },
 };
 
-function setup({ sendMethod, skipProfile } = {}) {
+function setup({ sendMethod, skipProfile, onWebhookVerify } = {}) {
   const mockLineAPIClient = {
     getUserProfile: jest.fn(),
     isValidSignature: jest.fn(),
@@ -100,6 +100,7 @@ function setup({ sendMethod, skipProfile } = {}) {
       channelSecret: CHANNEL_SECRET,
       sendMethod,
       skipProfile,
+      onWebhookVerify,
     }),
   };
 }
@@ -121,6 +122,19 @@ describe('#client', () => {
     const client = {};
     const connector = new LineConnector({ client });
     expect(connector.client).toBe(client);
+  });
+});
+
+describe('#onWebhookVerify', () => {
+  it('should be function', () => {
+    const onWebhookVerify = () => {};
+    const { connector } = setup({ onWebhookVerify });
+    expect(connector.onWebhookVerify).toBe(onWebhookVerify);
+  });
+
+  it('should be undefined when not config', () => {
+    const { connector } = setup();
+    expect(connector.onWebhookVerify).toBeUndefined();
   });
 });
 

--- a/src/express/__tests__/verifyLineWebhook.spec.js
+++ b/src/express/__tests__/verifyLineWebhook.spec.js
@@ -76,6 +76,17 @@ it('should correctly response 200 when is webhook verify request', () => {
   expect(next).not.toBeCalled();
 });
 
+it('should call onWebhookVerify when is webhook verify request', () => {
+  const { bot, middleware, req, res, next } = setup();
+
+  bot.connector.onWebhookVerify = jest.fn();
+  bot.connector.isWebhookVerifyRequest.mockReturnValueOnce(true);
+
+  middleware(req, res, next);
+
+  expect(bot.connector.onWebhookVerify).toBeCalledWith({ req, res });
+});
+
 it('should call next when is not webhook verify request', () => {
   const { bot, middleware, req, res, next } = setup();
 

--- a/src/express/verifyLineWebhook.js
+++ b/src/express/verifyLineWebhook.js
@@ -1,5 +1,8 @@
 const verifyLineWebhook = bot => (req, res, next) => {
   if (bot.connector.isWebhookVerifyRequest(req.body)) {
+    if (bot.connector.onWebhookVerify) {
+      bot.connector.onWebhookVerify({ req, res });
+    }
     res.sendStatus(200);
   } else {
     return next();

--- a/src/koa/__tests__/verifyLineWebhook.spec.js
+++ b/src/koa/__tests__/verifyLineWebhook.spec.js
@@ -74,6 +74,17 @@ it('should correctly response 200 when is webhook verify request', () => {
   expect(next).not.toBeCalled();
 });
 
+it('should call onWebhookVerify when is webhook verify request', () => {
+  const { bot, middleware, ctx, next } = setup();
+
+  bot.connector.onWebhookVerify = jest.fn();
+  bot.connector.isWebhookVerifyRequest.mockReturnValueOnce(true);
+
+  middleware(ctx, next);
+
+  expect(bot.connector.onWebhookVerify).toBeCalledWith(ctx);
+});
+
 it('should call next when is not webhook verify request', () => {
   const { bot, middleware, ctx, next } = setup();
 

--- a/src/koa/verifyLineWebhook.js
+++ b/src/koa/verifyLineWebhook.js
@@ -1,5 +1,9 @@
-const verifyLineWebhook = bot => ({ request, response }, next) => {
+const verifyLineWebhook = bot => (ctx, next) => {
+  const { request, response } = ctx;
   if (bot.connector.isWebhookVerifyRequest(request.body)) {
+    if (bot.connector.onWebhookVerify) {
+      bot.connector.onWebhookVerify(ctx);
+    }
     response.status = 200;
   } else {
     return next();

--- a/src/micro/__tests__/verifyLineWebhook.spec.js
+++ b/src/micro/__tests__/verifyLineWebhook.spec.js
@@ -75,6 +75,50 @@ it('should response 200 when verification pass', async () => {
   expect(micro.send).toBeCalledWith(res, 200);
 });
 
+it('should call onWebhookVerify when is webhook verify request', async () => {
+  const { bot, middleware, req, res } = setup();
+
+  micro.json.mockResolvedValueOnce({
+    events: [
+      {
+        replyToken: '00000000000000000000000000000000',
+        type: 'message',
+        timestamp: 1513065174862,
+        source: {
+          type: 'user',
+          userId: 'Udeadbeefdeadbeefdeadbeefdeadbeef',
+        },
+        message: {
+          id: '100001',
+          type: 'text',
+          text: 'Hello, world',
+        },
+      },
+      {
+        replyToken: 'ffffffffffffffffffffffffffffffff',
+        type: 'message',
+        timestamp: 1513065174862,
+        source: {
+          type: 'user',
+          userId: 'Udeadbeefdeadbeefdeadbeefdeadbeef',
+        },
+        message: {
+          id: '100002',
+          type: 'sticker',
+          packageId: '1',
+          stickerId: '1',
+        },
+      },
+    ],
+  });
+  bot.connector.onWebhookVerify = jest.fn();
+  bot.connector.isWebhookVerifyRequest.mockReturnValueOnce(true);
+
+  await middleware(req, res);
+
+  expect(bot.connector.onWebhookVerify).toBeCalledWith({ req, res });
+});
+
 it('should send 400 when verification fail', async () => {
   const { bot, middleware, req, res } = setup();
 

--- a/src/micro/verifyLineWebhook.js
+++ b/src/micro/verifyLineWebhook.js
@@ -4,6 +4,9 @@ const verifyLineWebhook = bot => async (req, res) => {
   const body = await json(req);
 
   if (bot.connector.isWebhookVerifyRequest(body)) {
+    if (bot.connector.onWebhookVerify) {
+      bot.connector.onWebhookVerify({ req, res });
+    }
     send(res, 200);
     return true;
   }

--- a/src/restify/__tests__/verifyLineWebhook.spec.js
+++ b/src/restify/__tests__/verifyLineWebhook.spec.js
@@ -76,6 +76,17 @@ it('should correctly response 200 when is webhook verify request', () => {
   expect(next).not.toBeCalled();
 });
 
+it('should call onWebhookVerify when is webhook verify request', () => {
+  const { bot, middleware, req, res, next } = setup();
+
+  bot.connector.onWebhookVerify = jest.fn();
+  bot.connector.isWebhookVerifyRequest.mockReturnValueOnce(true);
+
+  middleware(req, res, next);
+
+  expect(bot.connector.onWebhookVerify).toBeCalledWith({ req, res });
+});
+
 it('should call next when is not webhook verify request', () => {
   const { bot, middleware, req, res, next } = setup();
 

--- a/src/restify/verifyLineWebhook.js
+++ b/src/restify/verifyLineWebhook.js
@@ -1,5 +1,8 @@
 const verifyLineWebhook = bot => (req, res, next) => {
   if (bot.connector.isWebhookVerifyRequest(req.rawBody)) {
+    if (bot.connector.onWebhookVerify) {
+      bot.connector.onWebhookVerify({ req, res });
+    }
     return res.send(200);
   }
   return next();


### PR DESCRIPTION
- naming
- should call onWebhookVerify too, even when signature check failed. (can do this later)