### PR TITLE
fix(ngrok): find tunnel by proto

### DIFF
--- a/packages/bottender/src/cli/providers/messenger/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/setWebhook.spec.ts
@@ -116,7 +116,7 @@ describe('resolve', () => {
 
     await setWebhook(ctx);
 
-    expect(getWebhookFromNgrok).toBeCalledWith('4040');
+    expect(getWebhookFromNgrok).toBeCalledWith(undefined);
     expect(client.createSubscription).toBeCalledWith({
       access_token: '__APP_ID__|__APP_SECRET__',
       callback_url: 'https://fakeDomain.ngrok.io',

--- a/packages/bottender/src/cli/providers/messenger/webhook.ts
+++ b/packages/bottender/src/cli/providers/messenger/webhook.ts
@@ -44,7 +44,7 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
   });
 
   let webhook = argv['--webhook'];
-  const ngrokPort = argv['--ngrok-port'] || '4040';
+  const ngrokPort = argv['--ngrok-port'];
 
   try {
     const config = getConfig('messenger');

--- a/packages/bottender/src/cli/providers/telegram/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/telegram/__tests__/setWebhook.spec.ts
@@ -69,7 +69,7 @@ describe('resolve', () => {
 
     await setWebhook(ctx);
 
-    expect(getWebhookFromNgrok).toBeCalledWith('4040');
+    expect(getWebhookFromNgrok).toBeCalledWith(undefined);
     expect(log.print).toHaveBeenCalledTimes(1);
     expect(log.print.mock.calls[0][0]).toMatch(/Successfully/);
   });

--- a/packages/bottender/src/cli/providers/telegram/webhook.ts
+++ b/packages/bottender/src/cli/providers/telegram/webhook.ts
@@ -44,7 +44,7 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
     '--ngrok-port': String,
   });
 
-  const ngrokPort = argv['--ngrok-port'] || '4040';
+  const ngrokPort = argv['--ngrok-port'];
   let webhook = argv['--webhook'];
 
   try {

--- a/packages/bottender/src/cli/providers/viber/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/viber/__tests__/setWebhook.spec.ts
@@ -102,7 +102,7 @@ describe('resolve', () => {
 
     await setWebhook(ctx);
 
-    expect(getWebhookFromNgrok).toBeCalledWith('4040');
+    expect(getWebhookFromNgrok).toBeCalledWith(undefined);
     expect(client.setWebhook).toBeCalledWith(
       'https://fakeDomain.ngrok.io',
       undefined

--- a/packages/bottender/src/cli/providers/viber/webhook.ts
+++ b/packages/bottender/src/cli/providers/viber/webhook.ts
@@ -24,7 +24,7 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
   });
 
   let webhook = argv['--webhook'];
-  const ngrokPort = argv['--ngrok-port'] || '4040';
+  const ngrokPort = argv['--ngrok-port'];
 
   try {
     const config: ViberConfig = getConfig('viber');

--- a/packages/bottender/src/cli/shared/__tests__/getWebhookFromNgrok.spec.ts
+++ b/packages/bottender/src/cli/shared/__tests__/getWebhookFromNgrok.spec.ts
@@ -4,29 +4,110 @@ import getWebhookFromNgrok from '../getWebhookFromNgrok';
 
 jest.mock('axios');
 
+const res = {
+  data: {
+    tunnels: [
+      {
+        name: 'command_line',
+        uri: '/api/tunnels/command_line',
+        public_url: 'https://d95211d2.ngrok.io',
+        proto: 'https',
+        config: {
+          addr: 'localhost:80',
+          inspect: true,
+        },
+        metrics: {
+          conns: {
+            count: 0,
+            gauge: 0,
+            rate1: 0,
+            rate5: 0,
+            rate15: 0,
+            p50: 0,
+            p90: 0,
+            p95: 0,
+            p99: 0,
+          },
+          http: {
+            count: 0,
+            rate1: 0,
+            rate5: 0,
+            rate15: 0,
+            p50: 0,
+            p90: 0,
+            p95: 0,
+            p99: 0,
+          },
+        },
+      },
+      {
+        name: 'command_line',
+        uri: '/api/tunnels/command_line',
+        public_url: 'http://d95211d2.ngrok.io',
+        proto: 'http',
+        config: {
+          addr: 'localhost:80',
+          inspect: true,
+        },
+        metrics: {
+          conns: {
+            count: 0,
+            gauge: 0,
+            rate1: 0,
+            rate5: 0,
+            rate15: 0,
+            p50: 0,
+            p90: 0,
+            p95: 0,
+            p99: 0,
+          },
+          http: {
+            count: 0,
+            rate1: 0,
+            rate5: 0,
+            rate15: 0,
+            p50: 0,
+            p90: 0,
+            p95: 0,
+            p99: 0,
+          },
+        },
+      },
+    ],
+  },
+};
+
 it('be defined', () => {
   expect(getWebhookFromNgrok).toBeDefined();
 });
 
-it('call axios.create and return correct url', async () => {
-  axios.create.mockReturnValue({
-    get: jest.fn().mockResolvedValue({
-      data: {
-        tunnels: [
-          {
-            public_url: 'http://fakeDomain_1.ngrok.io',
-          },
-          {
-            public_url: 'https://fakeDomain_2.ngrok.io',
-          },
-        ],
-      },
-    }),
+it('create axios with 4040 port and return the correct url', async () => {
+  const axiosInstance = {
+    get: jest.fn().mockResolvedValue(res),
+  };
+
+  axios.create.mockReturnValue(axiosInstance);
+
+  const webhook = await getWebhookFromNgrok();
+
+  expect(webhook).toBe('https://d95211d2.ngrok.io');
+
+  expect(axios.create).toBeCalledWith({
+    baseURL: 'http://localhost:4040',
   });
+});
+
+it('create axios with specified port and return correct url', async () => {
+  const axiosInstance = {
+    get: jest.fn().mockResolvedValue(res),
+  };
+
+  axios.create.mockReturnValue(axiosInstance);
 
   const webhook = await getWebhookFromNgrok('5555');
 
-  expect(webhook).toBe('https://fakeDomain_2.ngrok.io');
+  expect(webhook).toBe('https://d95211d2.ngrok.io');
+
   expect(axios.create).toBeCalledWith({
     baseURL: 'http://localhost:5555',
   });

--- a/packages/bottender/src/cli/shared/getWebhookFromNgrok.ts
+++ b/packages/bottender/src/cli/shared/getWebhookFromNgrok.ts
@@ -1,12 +1,60 @@
 import axios from 'axios';
-import get from 'lodash/get';
 
-export default async function getWebhookFromNgrok(ngrokPort: string) {
+type Tunnel = {
+  name: string;
+  uri: string;
+  public_url: string;
+  proto: string;
+  config: {
+    addr: string;
+    inspect: boolean;
+  };
+  metrics: {
+    conns: {
+      count: number;
+      gauge: number;
+      rate1: number;
+      rate5: number;
+      rate15: number;
+      p50: number;
+      p90: number;
+      p95: number;
+      p99: number;
+    };
+    http: {
+      count: number;
+      rate1: number;
+      rate5: number;
+      rate15: number;
+      p50: number;
+      p90: number;
+      p95: number;
+      p99: number;
+    };
+  };
+};
+
+export default async function getWebhookFromNgrok(
+  ngrokPort = '4040'
+): Promise<string | never> {
+  // ngork API reference: https://ngrok.com/docs#client-api
   const ngrokAxios = axios.create({
     baseURL: `http://localhost:${ngrokPort}`,
   });
 
-  // TODO: use ngrok Client API? - https://ngrok.com/docs#client-api
-  const res = await ngrokAxios.get('/api/tunnels');
-  return get(res, 'data.tunnels[1].public_url'); // tunnels[1] return `https` protocol
+  const { data } = await ngrokAxios.get<{
+    tunnels: Tunnel[];
+  }>('/api/tunnels');
+
+  if (!data) {
+    throw new Error('Failed to get tunnels from ngrok');
+  }
+
+  const httpsTunnel = data.tunnels.find(tunnel => tunnel.proto === 'https');
+
+  if (!httpsTunnel) {
+    throw new Error('Can not find a https tunnel');
+  }
+
+  return httpsTunnel.public_url;
 }


### PR DESCRIPTION
Recently, I found that the tunnels are ordered randomly in this version, so we should find the right tunnel by the protocol.