### PR TITLE
fix: apply path in bottender.config.js in webhook setting process

### DIFF
--- a/packages/bottender/src/cli/providers/messenger/__tests__/createPersona.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/createPersona.spec.ts
@@ -48,7 +48,9 @@ describe('resolved', () => {
 
     await createPersona(ctx);
 
-    expect(MessengerClient.connect).toBeCalledWith('__FAKE_TOKEN__');
+    expect(MessengerClient.connect).toBeCalledWith({
+      accessToken: '__FAKE_TOKEN__',
+    });
     expect(_client.createPersona).toBeCalledWith({
       name: 'kpman',
       profile_picture_url: 'https://i.imgur.com/zV6uy4T.jpg',

--- a/packages/bottender/src/cli/providers/messenger/__tests__/deletePersona.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/deletePersona.spec.ts
@@ -45,7 +45,9 @@ describe('resolved', () => {
 
     await deletePersona(ctx);
 
-    expect(MessengerClient.connect).toBeCalledWith('__FAKE_TOKEN__');
+    expect(MessengerClient.connect).toBeCalledWith({
+      accessToken: '__FAKE_TOKEN__',
+    });
     expect(_client.deletePersona).toBeCalledWith('54321');
   });
 

--- a/packages/bottender/src/cli/providers/messenger/__tests__/getPersona.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/getPersona.spec.ts
@@ -45,7 +45,9 @@ describe('resolved', () => {
 
     await getPersona(ctx);
 
-    expect(MessengerClient.connect).toBeCalledWith('__FAKE_TOKEN__');
+    expect(MessengerClient.connect).toBeCalledWith({
+      accessToken: '__FAKE_TOKEN__',
+    });
     expect(_client.getPersona).toBeCalledWith('54321');
   });
 

--- a/packages/bottender/src/cli/providers/messenger/__tests__/listPersona.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/listPersona.spec.ts
@@ -46,7 +46,9 @@ describe('resolved', () => {
 
     await listPersona(ctx);
 
-    expect(MessengerClient.connect).toBeCalledWith('__FAKE_TOKEN__');
+    expect(MessengerClient.connect).toBeCalledWith({
+      accessToken: '__FAKE_TOKEN__',
+    });
     expect(_client.getAllPersonas).toBeCalled();
   });
 

--- a/packages/bottender/src/cli/providers/messenger/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/setWebhook.spec.ts
@@ -116,10 +116,10 @@ describe('resolve', () => {
 
     await setWebhook(ctx);
 
-    expect(getWebhookFromNgrok).toBeCalledWith(undefined);
+    expect(getWebhookFromNgrok).toBeCalledWith('4040');
     expect(client.createSubscription).toBeCalledWith({
       access_token: '__APP_ID__|__APP_SECRET__',
-      callback_url: 'https://fakeDomain.ngrok.io',
+      callback_url: 'https://fakeDomain.ngrok.io/webhooks/messenger',
       fields: [
         'messages',
         'messaging_postbacks',

--- a/packages/bottender/src/cli/providers/messenger/persona.ts
+++ b/packages/bottender/src/cli/providers/messenger/persona.ts
@@ -56,14 +56,22 @@ export async function createPersona(ctx: CliContext): Promise<void> {
   try {
     const config = getConfig('messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken } = config;
 
-    const accessToken = config.accessToken;
+    invariant(accessToken, 'accessToken is not found in config file');
 
-    invariant(personaName, 'Name is not specified!!');
-    invariant(personaUrl, 'Profile picture url is not specified!!');
+    invariant(
+      personaName,
+      '`name` is required but not found. Use --name <name> to specify persona name'
+    );
+    invariant(
+      personaUrl,
+      '`pic` is required but not found. Use --pic <url> to specify persona profile picture url'
+    );
 
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     const persona = {
       name: personaName as string,
@@ -73,9 +81,9 @@ export async function createPersona(ctx: CliContext): Promise<void> {
     const personaID = await client.createPersona(persona);
 
     print(`Successfully create ${bold('persona')} ${bold(personaID.id)}`);
-    return;
   } catch (err) {
     error(`Failed to create ${bold('persona')}`);
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -84,19 +92,22 @@ export async function createPersona(ctx: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }
 
-export async function listPersona(_: CliContext) {
+export async function listPersona(_: CliContext): Promise<void> {
   try {
     const config = getConfig('messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken } = config;
 
-    const accessToken = config.accessToken;
+    invariant(accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     const personas = await client.getAllPersonas();
 
@@ -113,7 +124,6 @@ export async function listPersona(_: CliContext) {
     } else {
       print('No personas are found.');
     }
-    return;
   } catch (err) {
     error(`Failed to list ${bold('personas')}`);
     if (err.response) {
@@ -138,13 +148,17 @@ export async function getPersona(ctx: CliContext): Promise<void> {
   try {
     const config = getConfig('messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken } = config;
 
-    const accessToken = config.accessToken;
+    invariant(accessToken, 'accessToken is not found in config file');
+    invariant(
+      personaId,
+      '`id` is required but not found. Use --id <id> to specify persona id'
+    );
 
-    invariant(personaId, 'Persona ID is not specified!!');
-
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     const persona = await client.getPersona(personaId as string);
 
@@ -155,11 +169,11 @@ export async function getPersona(ctx: CliContext): Promise<void> {
     } else {
       print(`Cannot get persona of ID ${bold(personaId as string)}`);
     }
-    return;
   } catch (err) {
     error(
       `Failed to get ${bold('persona')} of ID ${bold(personaId as string)}`
     );
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -168,6 +182,7 @@ export async function getPersona(ctx: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }
@@ -182,13 +197,17 @@ export async function deletePersona(ctx: CliContext): Promise<void> {
   try {
     const config = getConfig('messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken } = config;
 
-    const accessToken = config.accessToken;
+    invariant(accessToken, 'accessToken is not found in config file');
+    invariant(
+      personaId,
+      '`id` is required but not found. Use --id <id> to specify persona id'
+    );
 
-    invariant(personaId, 'Persona ID is not specified!!');
-
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     const res = await client.deletePersona(personaId as string);
 
@@ -197,11 +216,11 @@ export async function deletePersona(ctx: CliContext): Promise<void> {
     } else {
       print(`Cannot get persona of ID ${bold(personaId as string)}`);
     }
-    return;
   } catch (err) {
     error(
       `Failed to delete ${bold('persona')} of ID ${bold(personaId as string)}`
     );
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -210,6 +229,7 @@ export async function deletePersona(ctx: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }

--- a/packages/bottender/src/cli/providers/messenger/profile.ts
+++ b/packages/bottender/src/cli/providers/messenger/profile.ts
@@ -76,11 +76,13 @@ export async function getMessengerProfile(_: CliContext): Promise<void> {
   try {
     const config = getConfig('messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken } = config;
 
-    const accessToken = config.accessToken;
+    invariant(accessToken, 'accessToken is not found in config file');
 
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     const profile = await client.getMessengerProfile(FIELDS);
 
@@ -91,9 +93,9 @@ export async function getMessengerProfile(_: CliContext): Promise<void> {
     } else {
       error(`Failed to find ${bold('messenger_profile')} setting`);
     }
-    return;
   } catch (err) {
     error(`Failed to get ${bold('messenger_profile')} settings`);
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -102,6 +104,7 @@ export async function getMessengerProfile(_: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }
@@ -117,21 +120,25 @@ export async function setMessengerProfile(ctx: CliContext): Promise<void> {
   try {
     const config = getConfig('messenger');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken } = config;
 
-    const accessToken = config.accessToken;
+    invariant(accessToken, 'accessToken is not found in config file');
 
     const { profile: _profile } = getConfig('messenger');
 
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     if (force) {
       await client.deleteMessengerProfile(FIELDS);
+
       print(
         `Successfully delete all ${bold(
           'messenger_profile'
         )} settings due to ${bold('--force')} option`
       );
+
       if (_profile.whitelisted_domains) {
         await client.setMessengerProfile(pick(_profile, 'whitelisted_domains'));
         await client.setMessengerProfile(omit(_profile, 'whitelisted_domains'));
@@ -189,9 +196,9 @@ export async function setMessengerProfile(ctx: CliContext): Promise<void> {
         'bottender messenger profile get'
       )} to see the full profile setting.`
     );
-    return;
   } catch (err) {
     error(`Failed to set ${bold('messenger_profile')} settings`);
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -200,6 +207,7 @@ export async function setMessengerProfile(ctx: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }
@@ -212,14 +220,16 @@ export async function deleteMessengerProfile(_: CliContext): Promise<void> {
 
     const accessToken = config.accessToken;
 
-    const client = MessengerClient.connect(accessToken);
+    const client = MessengerClient.connect({
+      accessToken,
+    });
 
     await client.deleteMessengerProfile(FIELDS);
 
     print(`Successfully delete ${bold('messenger_profile')} settings`);
-    return;
   } catch (err) {
     error(`Failed to delete ${bold('messenger_profile')} settings`);
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -228,6 +238,7 @@ export async function deleteMessengerProfile(_: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }

--- a/packages/bottender/src/cli/providers/telegram/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/telegram/__tests__/setWebhook.spec.ts
@@ -69,7 +69,7 @@ describe('resolve', () => {
 
     await setWebhook(ctx);
 
-    expect(getWebhookFromNgrok).toBeCalledWith(undefined);
+    expect(getWebhookFromNgrok).toBeCalledWith('4040');
     expect(log.print).toHaveBeenCalledTimes(1);
     expect(log.print.mock.calls[0][0]).toMatch(/Successfully/);
   });

--- a/packages/bottender/src/cli/providers/viber/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/viber/__tests__/setWebhook.spec.ts
@@ -71,6 +71,9 @@ describe('resolve', () => {
     const { client } = setup({
       config: {
         accessToken: ACCESS_TOKEN,
+        sender: {
+          name: 'sender',
+        },
         eventTypes: ['delivered', 'seen'],
       },
     });
@@ -102,9 +105,9 @@ describe('resolve', () => {
 
     await setWebhook(ctx);
 
-    expect(getWebhookFromNgrok).toBeCalledWith(undefined);
+    expect(getWebhookFromNgrok).toBeCalledWith('4040');
     expect(client.setWebhook).toBeCalledWith(
-      'https://fakeDomain.ngrok.io',
+      'https://fakeDomain.ngrok.io/webhooks/viber',
       undefined
     );
     expect(log.print).toBeCalled();

--- a/packages/bottender/src/cli/providers/viber/webhook.ts
+++ b/packages/bottender/src/cli/providers/viber/webhook.ts
@@ -14,6 +14,7 @@ type ViberConfig = {
   accessToken: string;
   sender: ViberSender;
   eventTypes: ViberEventType[];
+  path?: string;
 };
 
 export async function setWebhook(ctx: CliContext): Promise<void> {
@@ -24,23 +25,35 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
   });
 
   let webhook = argv['--webhook'];
-  const ngrokPort = argv['--ngrok-port'];
+  const ngrokPort = argv['--ngrok-port'] || '4040';
 
   try {
     const config: ViberConfig = getConfig('viber');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken, sender, path = '/webhooks/viber' } = config;
 
-    const client = ViberClient.connect(config.accessToken, config.sender);
+    invariant(accessToken, 'accessToken is not found in config file');
+    invariant(sender, 'sender is not found in config file');
+
+    const client = ViberClient.connect(
+      {
+        accessToken,
+        sender,
+      },
+      sender
+    );
 
     if (!webhook) {
       warn('We can not find the webhook callback url you provided.');
+
       const prompt = new Confirm(
         `Are you using ngrok (get url from ngrok server on http://127.0.0.1:${ngrokPort})?`
       );
+
       const result = await prompt.run();
+
       if (result) {
-        webhook = await getWebhookFromNgrok(ngrokPort);
+        webhook = `${await getWebhookFromNgrok(ngrokPort)}${path}`;
       }
     }
 
@@ -54,6 +67,7 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
     print('Successfully set Viber webhook callback URL');
   } catch (err) {
     error('Failed to set Viber webhook');
+
     if (err.response) {
       error(`status: ${bold(err.response.status)}`);
       if (err.response.data) {
@@ -62,6 +76,7 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }
@@ -70,14 +85,22 @@ export async function deleteWebhook(_: CliContext): Promise<void> {
   try {
     const config: ViberConfig = getConfig('viber');
 
-    invariant(config.accessToken, 'accessToken is not found in config file');
+    const { accessToken, sender } = config;
 
-    const client = ViberClient.connect(config.accessToken, config.sender);
+    invariant(accessToken, 'accessToken is not found in config file');
+    invariant(sender, 'sender is not found in config file');
+
+    const client = ViberClient.connect(
+      {
+        accessToken,
+        sender,
+      },
+      sender
+    );
 
     await client.removeWebhook();
 
     print('Successfully delete Viber webhook');
-    return;
   } catch (err) {
     error('Failed to delete Viber webhook');
     if (err.response) {
@@ -88,6 +111,7 @@ export async function deleteWebhook(_: CliContext): Promise<void> {
     } else {
       error(err.message);
     }
+
     return process.exit(1);
   }
 }
@@ -96,10 +120,9 @@ export default async function main(ctx: CliContext): Promise<void> {
   const subcommand = ctx.argv._[2];
 
   switch (subcommand) {
-    case 'set': {
+    case 'set':
       await setWebhook(ctx);
       break;
-    }
     case 'delete':
     case 'del':
       await deleteWebhook(ctx);

--- a/packages/bottender/src/cli/shared/__fixtures__/tooManyMessengerFirstLayer.ts
+++ b/packages/bottender/src/cli/shared/__fixtures__/tooManyMessengerFirstLayer.ts
@@ -15,38 +15,6 @@ export default {
             composer_input_disabled: true,
             call_to_actions: [
               {
-                title: 'My Account',
-                type: 'nested',
-                call_to_actions: [
-                  {
-                    title: 'My Account',
-                    type: 'nested',
-                    call_to_actions: [
-                      {
-                        title: 'Contact Info',
-                        type: 'postback',
-                        payload: 'CONTACT_INFO_PAYLOAD',
-                      },
-                    ],
-                  },
-                  {
-                    title: 'Pay Bill',
-                    type: 'postback',
-                    payload: 'PAYBILL_PAYLOAD',
-                  },
-                  {
-                    title: 'History',
-                    type: 'postback',
-                    payload: 'HISTORY_PAYLOAD',
-                  },
-                  {
-                    title: 'Contact Info',
-                    type: 'postback',
-                    payload: 'CONTACT_INFO_PAYLOAD',
-                  },
-                ],
-              },
-              {
                 type: 'web_url',
                 title: 'Latest News',
                 url: 'http://petershats.parseapp.com/hat-news',
@@ -59,10 +27,14 @@ export default {
                 webview_height_ratio: 'full',
               },
               {
-                type: 'web_url',
-                title: 'Latest News',
-                url: 'http://petershats.parseapp.com/hat-news',
-                webview_height_ratio: 'full',
+                title: 'History',
+                type: 'postback',
+                payload: 'HISTORY_PAYLOAD',
+              },
+              {
+                title: 'Contact Info',
+                type: 'postback',
+                payload: 'CONTACT_INFO_PAYLOAD',
               },
             ],
           },

--- a/packages/bottender/src/cli/shared/schema.ts
+++ b/packages/bottender/src/cli/shared/schema.ts
@@ -1,7 +1,20 @@
 import Joi from '@hapi/joi';
 
 const menuItemSchema = Joi.object().keys({
-  // TODO:
+  type: Joi.string(),
+  title: Joi.string(),
+  url: Joi.string().when('type', {
+    is: 'web_url',
+    then: Joi.string().required(),
+  }),
+  payload: Joi.string().when('type', {
+    is: 'postback',
+    then: Joi.string().required(),
+  }),
+  webview_height_ratio: Joi.string(),
+  messenger_extensions: Joi.boolean(),
+  fallback_url: Joi.string(),
+  webview_share_button: Joi.string(),
 });
 
 const schema = Joi.object().keys({


### PR DESCRIPTION
When we use the following commands:

```
bottender messenger webhook set
bottender telegram webhook set
bottender viber webhook set
```

It can get your `path` configured in the `bottender.config.js` and match the behavior with `bottender start/dev`.