### PR TITLE
fix(create-bottender-app): fix some eslint errors

### DIFF
--- a/packages/create-bottender-app/src/index.ts
+++ b/packages/create-bottender-app/src/index.ts
@@ -329,6 +329,7 @@ const createBot = async (
     private: true,
     scripts: {
       dev: 'bottender dev',
+      lint: 'eslint .',
       start: 'bottender start',
       test: 'jest',
       ...(useTypescript
@@ -394,6 +395,9 @@ const init = async (): Promise<void> => {
     print('');
     print(`  ${command} dev`);
     print('    Starts the development server.');
+    print('');
+    print(`  ${command} lint`);
+    print('    Checks the code with the linter.');
     print('');
     print('We suggest that you begin by typing:');
     print('');

--- a/packages/create-bottender-app/template-typescript/.eslintrc.js
+++ b/packages/create-bottender-app/template-typescript/.eslintrc.js
@@ -20,4 +20,12 @@ module.exports = {
     ],
   },
   plugins: ['prettier', '@typescript-eslint'],
+  overrides: [
+    {
+      files: ['**/*.test.ts'],
+      env: {
+        jest: true,
+      },
+    },
+  ],
 };

--- a/packages/create-bottender-app/template/.eslintrc.js
+++ b/packages/create-bottender-app/template/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  parserOptions: {
+    ecmaVersion: 2017,
+  },
   extends: ['eslint:recommended', 'prettier'],
   env: {
     node: true,
@@ -13,4 +16,12 @@ module.exports = {
     ],
   },
   plugins: ['prettier'],
+  overrides: [
+    {
+      files: ['**/*.test.js'],
+      env: {
+        jest: true,
+      },
+    },
+  ],
 };


### PR DESCRIPTION
- Add `lint` script to the template
- Set `parserOptions. ecmaVersion` to 2017 to avoid:

```
/Users/chentsulin/Projects/project/src/index.js
  1:24  error  Parsing error: Unexpected token function

/Users/chentsulin/Projects/project/src/index.test.js
  1:1  error  Parsing error: The keyword 'const' is reserved
```

- Set `env: { jest: true }` for test files to avoid:

```
/Users/chentsulin/Projects/project/src/index.test.js
  3:1  error  'describe' is not defined  no-undef
  4:3  error  'it' is not defined        no-undef
  5:5  error  'expect' is not defined    no-undef
```