### PR TITLE
removed(MessengerContext): remove deprecated sendAirlineFlightUp…

### DIFF
--- a/packages/bottender/src/context/MessengerContext.ts
+++ b/packages/bottender/src/context/MessengerContext.ts
@@ -551,9 +551,6 @@ const sendMethods: [string, number][] = [
   ['sendAirlineCheckinTemplate', 3],
   ['sendAirlineItineraryTemplate', 3],
   ['sendAirlineUpdateTemplate', 3],
-
-  // deprecated
-  ['sendAirlineFlightUpdateTemplate', 3],
 ];
 
 sendMethods.forEach(([method, arity]) => {


### PR DESCRIPTION
It has been deprecated for a while, so should be safe to remove it.