### PR TITLE
changed(Bot): make onError can receive an action

### DIFF
--- a/packages/bottender/src/bot/Bot.ts
+++ b/packages/bottender/src/bot/Bot.ts
@@ -9,7 +9,7 @@ import Context from '../context/Context';
 import MemoryCacheStore from '../cache/MemoryCacheStore';
 import Session from '../session/Session';
 import SessionStore from '../session/SessionStore';
-import { Action, Plugin } from '../types';
+import { Action, Plugin, Props } from '../types';
 
 import { Connector } from './Connector';
 
@@ -30,16 +30,24 @@ function createMemorySessionStore(): SessionStore {
   return new CacheBasedSessionStore(cache, MINUTES_IN_ONE_YEAR);
 }
 
-export function run(fn: Action): Action {
-  return async function Run(context: Context): Promise<void> {
-    let nextDialog: Action | void = fn;
+export function run(action: Action): Action {
+  return async function Run(
+    context: Context,
+    props: Props = {}
+  ): Promise<void> {
+    let nextDialog: Action | void = action;
 
-    do {
+    // TODO: refactor this with withProps or whatever
+    debugDialog(`Current Dialog: ${nextDialog.name || 'Anonymous'}`);
+    // eslint-disable-next-line no-await-in-loop
+    nextDialog = await nextDialog(context, props);
+
+    while (typeof nextDialog === 'function') {
       // TODO: improve this debug helper
       debugDialog(`Current Dialog: ${nextDialog.name || 'Anonymous'}`);
       // eslint-disable-next-line no-await-in-loop
       nextDialog = await nextDialog(context, {});
-    } while (typeof nextDialog === 'function');
+    }
 
     return nextDialog;
   };
@@ -58,6 +66,8 @@ export default class Bot<B, C> {
   _connector: Connector<B, C>;
 
   _handler: Action | null;
+
+  _errorHandler: Action | null;
 
   _initialState: Record<string, any> = {};
 
@@ -80,6 +90,7 @@ export default class Bot<B, C> {
     this._initialized = false;
     this._connector = connector;
     this._handler = null;
+    this._errorHandler = null;
     this._sync = sync;
     this._emitter = new EventEmitter();
   }
@@ -114,7 +125,7 @@ export default class Bot<B, C> {
       handler,
       'onError: Can not pass `undefined`, `null` or any falsy value as error handler'
     );
-    this._emitter.on('error', 'build' in handler ? handler.build() : handler);
+    this._errorHandler = 'build' in handler ? handler.build() : handler;
     return this;
   }
 
@@ -224,6 +235,7 @@ export default class Bot<B, C> {
         );
       }
       const handler: Action = this._handler;
+      const errorHandler: Action | null = this._errorHandler;
       const promises = Promise.all(
         contexts.map(context =>
           Promise.resolve()
@@ -232,6 +244,12 @@ export default class Bot<B, C> {
               if (context.handlerDidEnd) {
                 return context.handlerDidEnd();
               }
+            })
+            .catch(err => {
+              if (errorHandler) {
+                return run(errorHandler)(context, { error: err });
+              }
+              throw err;
             })
             .catch(err => {
               context.emitError(err);

--- a/packages/bottender/src/bot/__tests__/Bot.spec.ts
+++ b/packages/bottender/src/bot/__tests__/Bot.spec.ts
@@ -116,25 +116,25 @@ describe('#createRequestHandler', () => {
     connector.getUniqueSessionKey.mockReturnValue('__id__');
     sessionStore.read.mockResolvedValue(session);
 
-    const handler = jest.fn();
-    bot.onEvent(handler);
+    let receivedContext;
+    const Action = context => {
+      receivedContext = context;
+    };
+    bot.onEvent(Action);
 
     const requestHandler = bot.createRequestHandler();
 
     const body = {};
     await requestHandler(body);
 
-    expect(handler).toBeCalledWith(
-      {
-        event: {},
-        session: expect.objectContaining({
-          id: 'any:__id__',
-          platform: 'any',
-          user: {},
-        }),
-      },
-      {}
-    );
+    expect(receivedContext).toEqual({
+      event: {},
+      session: expect.objectContaining({
+        id: 'any:__id__',
+        platform: 'any',
+        user: {},
+      }),
+    });
   });
 
   it('should return response in sync mode', async () => {
@@ -233,19 +233,21 @@ describe('#createRequestHandler', () => {
 
     connector.getUniqueSessionKey.mockReturnValue(null);
 
-    const handler = jest.fn();
-    bot.onEvent(handler);
+    let receivedContext;
+    const Action = context => {
+      receivedContext = context;
+    };
+    bot.onEvent(Action);
 
     const requestHandler = bot.createRequestHandler();
 
     const body = {};
     await requestHandler(body);
 
-    expect(handler).toBeCalledWith(
+    expect(receivedContext).toEqual(
       expect.objectContaining({
         session: undefined,
-      }),
-      {}
+      })
     );
   });
 
@@ -444,47 +446,8 @@ describe('#onError', () => {
         .onEvent(() => {
           throw new Error('boom');
         })
-        .onError((err, context) => {
-          receivedError = err;
-          receivedContext = context;
-          resolve();
-        });
-    });
-
-    const requestHandler = bot.createRequestHandler();
-
-    await requestHandler({});
-
-    await promise;
-
-    expect(receivedError).toBeInstanceOf(Error);
-    expect(receivedContext).toBeInstanceOf(Context);
-  });
-
-  it('should receive emitted error and context', async () => {
-    const event = {};
-    const connector = {
-      platform: 'any',
-      getUniqueSessionKey: jest.fn(),
-      shouldSessionUpdate: jest.fn(),
-      updateSession: jest.fn(),
-      mapRequestToEvents: jest.fn(() => [event]),
-      createContext: ({ emitter }) =>
-        new Context({ event, session: undefined, emitter }),
-    };
-
-    const { bot } = setup({ connector });
-
-    let receivedError;
-    let receivedContext;
-
-    const promise = new Promise(resolve => {
-      bot
-        .onEvent(context => {
-          context.emitError(new Error('boom'));
-        })
-        .onError((err, context) => {
-          receivedError = err;
+        .onError((context, { error }) => {
+          receivedError = error;
           receivedContext = context;
           resolve();
         });


### PR DESCRIPTION
`onError` should only focus on the error happened on the context.