### PR TITLE
feat(start/dev): use process.env.PORT if it exists

### DIFF
--- a/packages/bottender/src/cli/providers/sh/dev.ts
+++ b/packages/bottender/src/cli/providers/sh/dev.ts
@@ -17,7 +17,7 @@ const dev = async (ctx: CliContext): Promise<void> => {
   });
 
   const isConsole = argv['--console'] || false;
-  const port = argv['--port'] || 5000;
+  const port = argv['--port'] || process.env.PORT || 5000;
 
   const config = getBottenderConfig();
 

--- a/packages/bottender/src/cli/providers/sh/start.ts
+++ b/packages/bottender/src/cli/providers/sh/start.ts
@@ -14,7 +14,7 @@ const start = async (ctx: CliContext): Promise<void> => {
   });
 
   const isConsole = argv['--console'] || false;
-  const port = argv['--port'] || 5000;
+  const port = argv['--port'] || process.env.PORT || 5000;
 
   const server = initializeServer({ isConsole });
 


### PR DESCRIPTION
So it can be deployed to Heroku and serve on port correctly.