### PR TITLE
feat: add customize sessionIdSeperator

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Call on '....'
 3. See error

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -4,7 +4,4 @@ about: Describe this issue template's purpose here.
 title: ''
 labels: ''
 assignees: ''
-
 ---
-
-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/packages/bottender/src/bot/Bot.ts
+++ b/packages/bottender/src/bot/Bot.ts
@@ -73,14 +73,18 @@ export default class Bot<B, C> {
 
   _emitter: EventEmitter;
 
+  _sessionIdSeperator: string;
+
   constructor({
     connector,
     sessionStore = createMemorySessionStore(),
     sync = false,
+    sessionIdSeperator = ':',
   }: {
     connector: Connector<B, C>;
     sessionStore?: SessionStore;
     sync?: boolean;
+    sessionIdSeperator?: string;
   }) {
     this._sessions = sessionStore;
     this._initialized = false;
@@ -88,6 +92,7 @@ export default class Bot<B, C> {
     this._handler = null;
     this._sync = sync;
     this._emitter = new EventEmitter();
+    this._sessionIdSeperator = sessionIdSeperator;
   }
 
   get connector(): Connector<B, C> {
@@ -169,7 +174,7 @@ export default class Bot<B, C> {
       let sessionId: string | undefined;
       let session: Session | undefined;
       if (sessionKey) {
-        sessionId = `${platform}:${sessionKey}`;
+        sessionId = `${platform}${this._sessionIdSeperator}${sessionKey}`;
 
         session =
           (await this._sessions.read(sessionId)) ||

--- a/packages/bottender/src/bot/ConsoleBot.ts
+++ b/packages/bottender/src/bot/ConsoleBot.ts
@@ -13,13 +13,15 @@ export default class ConsoleBot extends Bot<ConsoleRawEvent, ConsoleClient> {
     sessionStore,
     fallbackMethods,
     mockPlatform,
+    sessionIdSeperator = ':',
   }: {
     sessionStore?: SessionStore;
     fallbackMethods?: boolean;
     mockPlatform?: string;
+    sessionIdSeperator?: string;
   } = {}) {
     const connector = new ConsoleConnector({ fallbackMethods, mockPlatform });
-    super({ connector, sessionStore, sync: true });
+    super({ connector, sessionStore, sync: true, sessionIdSeperator });
   }
 
   async getSession(): Promise<Session> {
@@ -29,7 +31,7 @@ export default class ConsoleBot extends Bot<ConsoleRawEvent, ConsoleClient> {
     const sessionKey = '1';
 
     // Create or retrieve session if possible
-    const sessionId = `${platform}:${sessionKey}`;
+    const sessionId = `${platform}${this._sessionIdSeperator}${sessionKey}`;
     const session =
       (await this._sessions.read(sessionId)) ||
       (Object.create(null) as Session);

--- a/packages/bottender/src/bot/LineBot.ts
+++ b/packages/bottender/src/bot/LineBot.ts
@@ -16,6 +16,7 @@ export default class LineBot extends Bot<LineRequestBody, LineClient> {
     shouldBatch,
     sendMethod,
     skipProfile,
+    sessionIdSeperator = ':',
   }: {
     accessToken: string;
     channelSecret: string;
@@ -26,6 +27,7 @@ export default class LineBot extends Bot<LineRequestBody, LineClient> {
     sendMethod?: string;
     origin?: string;
     skipProfile?: boolean;
+    sessionIdSeperator?: string;
   }) {
     const connector = new LineConnector({
       accessToken,
@@ -36,6 +38,6 @@ export default class LineBot extends Bot<LineRequestBody, LineClient> {
       origin,
       skipProfile,
     });
-    super({ connector, sessionStore, sync });
+    super({ connector, sessionStore, sync, sessionIdSeperator });
   }
 }

--- a/packages/bottender/src/bot/MessengerBot.ts
+++ b/packages/bottender/src/bot/MessengerBot.ts
@@ -21,6 +21,7 @@ export default class MessengerBot extends Bot<
     origin,
     skipAppSecretProof,
     skipProfile,
+    sessionIdSeperator = ':',
   }: {
     accessToken: string;
     appId: string;
@@ -33,6 +34,7 @@ export default class MessengerBot extends Bot<
     origin?: string;
     skipAppSecretProof?: boolean;
     skipProfile?: boolean;
+    sessionIdSeperator?: string;
   }) {
     const connector = new MessengerConnector({
       accessToken,
@@ -45,6 +47,6 @@ export default class MessengerBot extends Bot<
       skipAppSecretProof,
       skipProfile,
     });
-    super({ connector, sessionStore, sync });
+    super({ connector, sessionStore, sync, sessionIdSeperator });
   }
 }

--- a/packages/bottender/src/bot/SlackBot.ts
+++ b/packages/bottender/src/bot/SlackBot.ts
@@ -16,6 +16,7 @@ export default class SlackBot extends Bot<SlackRequestBody, SlackOAuthClient> {
     verificationToken,
     origin,
     skipProfile,
+    sessionIdSeperator = ':',
   }: {
     accessToken: string;
     sessionStore: SessionStore;
@@ -23,6 +24,7 @@ export default class SlackBot extends Bot<SlackRequestBody, SlackOAuthClient> {
     verificationToken?: string;
     origin?: string;
     skipProfile?: boolean | null;
+    sessionIdSeperator?: string;
   }) {
     const connector = new SlackConnector({
       accessToken,
@@ -30,7 +32,7 @@ export default class SlackBot extends Bot<SlackRequestBody, SlackOAuthClient> {
       origin,
       skipProfile,
     });
-    super({ connector, sessionStore, sync });
+    super({ connector, sessionStore, sync, sessionIdSeperator });
     this._accessToken = accessToken;
   }
 

--- a/packages/bottender/src/bot/TelegramBot.ts
+++ b/packages/bottender/src/bot/TelegramBot.ts
@@ -25,14 +25,16 @@ export default class TelegramBot extends Bot<
     sessionStore,
     sync,
     origin,
+    sessionIdSeperator = ':',
   }: {
     accessToken: string;
     sessionStore: SessionStore;
     sync?: boolean;
     origin?: string;
+    sessionIdSeperator?: string;
   }) {
     const connector = new TelegramConnector({ accessToken, origin });
-    super({ connector, sessionStore, sync });
+    super({ connector, sessionStore, sync, sessionIdSeperator });
 
     this._offset = null;
     this._shouldGetUpdates = false;

--- a/packages/bottender/src/bot/ViberBot.ts
+++ b/packages/bottender/src/bot/ViberBot.ts
@@ -12,14 +12,16 @@ export default class ViberBot extends Bot<ViberRequestBody, ViberClient> {
     sessionStore,
     sync,
     origin,
+    sessionIdSeperator = ':',
   }: {
     accessToken: string;
     sender: ViberSender;
     sessionStore?: SessionStore;
     sync?: boolean;
     origin?: string;
+    sessionIdSeperator?: string;
   }) {
     const connector = new ViberConnector({ accessToken, sender, origin });
-    super({ connector, sessionStore, sync });
+    super({ connector, sessionStore, sync, sessionIdSeperator });
   }
 }


### PR DESCRIPTION
We find out that in windows file system `:` is not allow to be in the file's name which makes the file session not work quite well, so now you can use any string as a separator, just don't use those character that might in the platform user id

should close #413 