### PR TITLE
docs(errors): Add Sentry Section

### DIFF
--- a/docs/the-basics-errors.md
+++ b/docs/the-basics-errors.md
@@ -5,7 +5,7 @@ title: Error Handling
 
 ## Customizing the Error Message
 
-To customize the error message sending to the user, you may create an `_error.js` file in your project root:
+Bottender makes it easy to display custom error message for various runtime errors. To customize the error message sending to the user, you may create an `_error.js` file in your project root:
 
 ```js
 // _error.js
@@ -14,19 +14,52 @@ module.exports = async function HandleError(context, props) {
   await context.sendText(
     'There are some unexpected errors happened. Please try again later, sorry for the inconvenience.'
   );
+  console.error(props.error);
   if (process.env.NODE_ENV === 'production') {
     // send your error to the error tracker, for example: Sentry
   }
   if (process.env.NODE_ENV === 'development') {
     await context.sendText(props.error.stack);
   }
-  console.error(props.error);
 };
 ```
 
 According to the code in the above example, it will do following things for you:
 
 1. Send `There are some unexpected errors happened. Please try again later, sorry for the inconvenience.` text message to the end user.
-2. Log error into error tracker
-3. Send `error.stack` as text message to the user when developing the app.
-4. Log error to the console
+2. Log error to the console.
+3. Log error into error tracker.
+4. Send `error.stack` as text message to the user when developing the app.
+
+## Sending Errors to Sentry
+
+[Sentry](https://sentry.io) is an error tracking and monitoring tool that aggregates errors across your stack in real time.
+
+To integrate with it, first, you need to download the sdk from registry to use it:
+
+```sh
+# Using npm
+$ npm install @sentry/node
+
+# Using yarn
+$ yarn add @sentry/node
+```
+
+Then, add those few lines of code in your `_error.js` to send your runtime errors to Sentry. Make sure that you fill in you [DSN (Data Source Name)](https://docs.sentry.io/error-reporting/quickstart/?platform=node) to configure the Sentry instance:
+
+```js
+// _error.js
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'YOUR_SENTRY_DSN',
+});
+
+module.exports = async function HandleError(context, props) {
+  if (process.env.NODE_ENV === 'production') {
+    Sentry.captureException(props.error);
+  }
+};
+```
+
+When errors happen in production, those errors will be sent to Sentry automatically.


### PR DESCRIPTION
## Sending Errors to Sentry

[Sentry](https://sentry.io) is an error tracking and monitoring tool that aggregates errors across your stack in real time.

To integrate with it, first, you need to download the sdk from registry to use it:

```sh
# Using npm
$ npm install @sentry/node

# Using yarn
$ yarn add @sentry/node
```

Then, add those few lines of code in your `_error.js` to send your runtime errors to Sentry. Make sure that you fill in you [DSN (Data Source Name)](https://docs.sentry.io/error-reporting/quickstart/?platform=node) to configure the Sentry instance:

```js
// _error.js
const Sentry = require('@sentry/node');

Sentry.init({
  dsn: 'YOUR_SENTRY_DSN',
});

module.exports = async function HandleError(context, props) {
  if (process.env.NODE_ENV === 'production') {
    Sentry.captureException(props.error);
  }
};
```

When errors happen in production, those errors will be sent to Sentry automatically.
