### PR TITLE
feat(docs): add Algolia search integration

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -102,6 +102,15 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   //   repoUrl: 'https://github.com/facebook/test-site',
+
+  // Information for Algolia search integration.
+  algolia: {
+    apiKey: '3498a488684b0324b9d56808fad17a33',
+    indexName: 'bottender',
+    algoliaOptions: {
+      facetFilters: ['language:LANGUAGE', 'version:VERSION'],
+    },
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
I already submited the request for the Algolia  docsearch program. Once it get accepted, we can fill in the `apiKey ` and `indexName`.

https://community.algolia.com/docsearch/

https://github.com/algolia/docsearch-configs/blob/master/configs/bottender.json