### PR TITLE
fix(getBottenderConfig): use {} as default bottender.config.js

### DIFF
--- a/packages/bottender/src/shared/getBottenderConfig.ts
+++ b/packages/bottender/src/shared/getBottenderConfig.ts
@@ -10,8 +10,12 @@ dotenv.config();
  * By default, it will try to require the module from `<root>/bottender.config.js`.
  */
 const getBottenderConfig = (): BottenderConfig | never => {
-  // eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-var-requires
-  return require(path.resolve('bottender.config.js'));
+  try {
+    // eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-var-requires
+    return require(path.resolve('bottender.config.js'));
+  } catch (err) {
+    return {};
+  }
 };
 
 export default getBottenderConfig;

--- a/packages/bottender/src/types.ts
+++ b/packages/bottender/src/types.ts
@@ -96,7 +96,7 @@ export type BottenderConfig = {
       };
     };
   };
-  initialState: Record<string, any>;
+  initialState?: Record<string, any>;
   channels?: {
     [Channel.Messenger]: {
       enabled: boolean;


### PR DESCRIPTION
Fallback `bottender.config.js` to `{}` if it doesn't exist.