### PR TITLE
fix (slack): check block_actions type for block UI events

### DIFF
--- a/packages/bottender/src/bot/SlackConnector.ts
+++ b/packages/bottender/src/bot/SlackConnector.ts
@@ -8,6 +8,7 @@ import { SlackOAuthClient } from 'messaging-api-slack';
 import Session from '../session/Session';
 import SlackContext from '../context/SlackContext';
 import SlackEvent, {
+  BlockActionEvent,
   EventAPITypes,
   InteractiveMessageEvent,
   Message,
@@ -91,7 +92,11 @@ export default class SlackConnector
     }
 
     if (body.payload && typeof body.payload === 'string') {
-      return JSON.parse(body.payload) as InteractiveMessageEvent;
+      const payload = JSON.parse(body.payload);
+      if (payload.type === 'interactive_message') {
+        return payload as InteractiveMessageEvent;
+      }
+      return payload as BlockActionEvent;
     }
 
     // for RTM WebSocket messages
@@ -151,7 +156,10 @@ export default class SlackConnector
 
     const rawEvent = this._getRawEventFromRequest(body);
     let userFromBody;
-    if (rawEvent.type === 'interactive_message') {
+    if (
+      rawEvent.type === 'interactive_message' ||
+      rawEvent.type === 'block_actions'
+    ) {
       userFromBody = rawEvent.user.id;
     } else {
       userFromBody = (rawEvent as Message).user;


### PR DESCRIPTION
This change is for slack bot.

type `interactive_message` is outdated https://api.slack.com/docs/outmoded-messaging
We may want to use new type `block_actions` for block UIs

previous type checking causes the following error since it passes whole user object rather than user id
```
AxiosError: Slack API - user_not_found
    at SlackOAuthClient.<anonymous> (/Users/darkbtf/Documents/project/yoctol/yocbot/node_modules/messaging-api-slack/src/SlackOAuthClient.ts:181:3)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/darkbtf/Documents/project/yoctol/yocbot/node_modules/messaging-api-slack/dist/SlackOAuthClient.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```
