### PR TITLE
examples: use npx instead of global, and link to the new docs

### DIFF
--- a/examples/browser-only/README.md
+++ b/examples/browser-only/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/browser-only
 cd browser-only
 npm install

--- a/examples/echo-bot/README.md
+++ b/examples/echo-bot/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/echo-bot
 cd echo-bot
 npm install

--- a/examples/echo-bot/README.md
+++ b/examples/echo-bot/README.md
@@ -15,6 +15,4 @@ npm run dev -- --console
 
 This is a simple console bot which will echo what you said and shows how to
 distinguish what kind of message the bot has received. The easiest way is to use
-`context.event.isXXXXX`. It helps your bot recognize incoming requests.\
-Check our [event guide](https://bottender.js.org/docs/APIReference-Event/) for more
-information.
+`context.event.isText`. It helps your bot recognize incoming text events.

--- a/examples/line-hello-world/README.md
+++ b/examples/line-hello-world/README.md
@@ -34,7 +34,7 @@ To set the webhook, go to [LINE developers console](https://developers.line.me/c
 ## Idea of this example
 
 This example is a simple bot running on [LINE](https://line.me/).
-For more information, check our [LINE guides](https://bottender.js.org/docs/Platforms-LINE).
+For more information, check our [LINE guides](https://bottender.js.org/docs/channel-line-setup).
 
 ## Related examples
 

--- a/examples/line-hello-world/README.md
+++ b/examples/line-hello-world/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/line-hello-world
 cd line-hello-world
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken` and `channelSecret` into `index.js`.
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 

--- a/examples/messenger-batch-multi-pages/README.md
+++ b/examples/messenger-batch-multi-pages/README.md
@@ -31,10 +31,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
@@ -42,7 +42,7 @@ bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/) to reply separately by different page.\
-For more information, check our [Messenger guides](https://bottender.js.org/docs/Platforms-Messenger).
+For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
 ## Related examples
 

--- a/examples/messenger-batch-multi-pages/README.md
+++ b/examples/messenger-batch-multi-pages/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-batch-multi-pages
 cd messenger-batch-multi-pages
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -33,7 +33,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-batch/README.md
+++ b/examples/messenger-batch/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-batch
 cd messenger-batch
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-batch/README.md
+++ b/examples/messenger-batch/README.md
@@ -29,10 +29,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.

--- a/examples/messenger-built-in-nlp/README.md
+++ b/examples/messenger-built-in-nlp/README.md
@@ -31,10 +31,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.

--- a/examples/messenger-built-in-nlp/README.md
+++ b/examples/messenger-built-in-nlp/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-built-in-nlp
 cd messenger-built-in-nlp
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -21,7 +21,7 @@ Also, to enable built-in NLP, you should setup related settings following the of
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -33,7 +33,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-handover/README.md
+++ b/examples/messenger-handover/README.md
@@ -29,10 +29,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
@@ -40,7 +40,7 @@ bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 This example shows how to use [Messenger Handover Protocol](https://developers.facebook.com/docs/messenger-platform/handover-protocol) in Bottender bots.
-For more information, check our [Messenger guides](https://bottender.js.org/docs/Platforms-Messenger).
+For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
 ## Related examples
 

--- a/examples/messenger-handover/README.md
+++ b/examples/messenger-handover/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-handover
 cd messenger-handover
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-hello-world/README.md
+++ b/examples/messenger-hello-world/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-hello-world
 cd messenger-hello-world
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-hello-world/README.md
+++ b/examples/messenger-hello-world/README.md
@@ -29,10 +29,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
@@ -40,7 +40,7 @@ bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/).
-For more information, check our [Messenger guides](https://bottender.js.org/docs/Platforms-Messenger).
+For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
 ## Related examples
 

--- a/examples/messenger-multi-pages/README.md
+++ b/examples/messenger-multi-pages/README.md
@@ -31,10 +31,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
@@ -42,7 +42,7 @@ bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/) to reply separately by different page.\
-For more information, check our [Messenger guides](https://bottender.js.org/docs/Platforms-Messenger).
+For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
 ## Related examples
 

--- a/examples/messenger-multi-pages/README.md
+++ b/examples/messenger-multi-pages/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-multi-pages
 cd messenger-multi-pages
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -33,7 +33,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-persistent-menu/README.md
+++ b/examples/messenger-persistent-menu/README.md
@@ -35,10 +35,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
@@ -46,7 +46,7 @@ bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 It shows how to set a [persistent menu](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/persistent-menu/) on [Messenger](https://www.messenger.com/).
-For more information, check our [Messenger guides](https://bottender.js.org/docs/Platforms-Messenger).
+For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
 ## Related examples
 

--- a/examples/messenger-persistent-menu/README.md
+++ b/examples/messenger-persistent-menu/README.md
@@ -4,28 +4,28 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-persistent-menu
 cd messenger-persistent-menu
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
 You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
 
-To set messenger profile, run following command with global `bottender`:
+To set messenger profile, run following command with `bottender`:
 
-```
-bottender messenger profile set
+```sh
+npx bottender messenger profile set
 ```
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -37,7 +37,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-persona/README.md
+++ b/examples/messenger-persona/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-persona
 cd messenger-persona
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -27,13 +27,13 @@ This command will start server for bot developing at `http://localhost:5000`.
 
 If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
-> Note: You must set `PERSONA_1` and `PERSONA_2` env variables pairs before running this command. You can create them using `bottender messenger persona create --name <name> --pic <url>`.
+> Note: You must set `PERSONA_1` and `PERSONA_2` env variables pairs before running this command. You can create them using `npx bottender messenger persona create --name <name> --pic <url>`.
 
 ## Set webhook
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-persona/README.md
+++ b/examples/messenger-persona/README.md
@@ -31,10 +31,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
@@ -57,7 +57,7 @@ await context.sendText('hi', { persona_id: '<PERSONA_ID_1>' });
 await context.sendText('hi', { persona_id: '<PERSONA_ID_2>' });
 ```
 
-For more information, check our [Messenger guides](https://bottender.js.org/docs/Platforms-Messenger).
+For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
 ## Related examples
 

--- a/examples/messenger-typing/README.md
+++ b/examples/messenger-typing/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/messenger-typing
 cd messenger-typing
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/messenger-typing/README.md
+++ b/examples/messenger-typing/README.md
@@ -29,10 +29,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.

--- a/examples/multiple-channels/README.md
+++ b/examples/multiple-channels/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/cross-platform
 cd cross-platform
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put all needed information into `bottender.config.js`.
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get webhook urls correspond to ea
 
 You must set webhooks correspond to mounted paths properly:
 
-```
+```sh
 <YOUR_BASE_URL>/messenger
 <YOUR_BASE_URL>/line
 <YOUR_BASE_URL>/slack

--- a/examples/session-file/README.md
+++ b/examples/session-file/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/session-file
 cd session-file
 npm install
@@ -15,7 +15,7 @@ npm run dev -- --console
 
 This example shows how to use Session to store some information from users and
 store sessions in your local file. For more information, check our
-[session guide](https://bottender.js.org/docs/Guides-Session).
+[session guide](https://bottender.js.org/docs/the-basics-session).
 
 ## Related examples
 

--- a/examples/session-memory/README.md
+++ b/examples/session-memory/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/session-memory
 cd session-memory
 npm install
@@ -15,7 +15,7 @@ npm run dev -- --console
 
 This example shows how to use Session to store some information from users. For
 more information, check our
-[session guide](https://bottender.js.org/docs/Guides-Session).
+[session guide](https://bottender.js.org/docs/the-basics-session).
 
 ## Related examples
 

--- a/examples/session-mongo/README.md
+++ b/examples/session-mongo/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/session-mongo
 cd session-mongo
 npm install
@@ -15,7 +15,7 @@ npm run dev -- --console
 
 This example shows how to use Session to store some information from users and
 store sessions in your MongoDB. For more information, check our
-[session guide](https://bottender.js.org/docs/Guides-Session).
+[session guide](https://bottender.js.org/docs/the-basics-session).
 
 ## Related examples
 

--- a/examples/session-redis/README.md
+++ b/examples/session-redis/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/session-redis
 cd session-redis
 npm install
@@ -33,7 +33,7 @@ module.exports = {
 
 This example shows how to use Session to store some information from users and
 store sessions in your Redis server. For more information, check our
-[session guide](https://bottender.js.org/docs/Guides-Session).
+[session guide](https://bottender.js.org/docs/the-basics-session).
 
 ## Related examples
 

--- a/examples/slack-hello-world/README.md
+++ b/examples/slack-hello-world/README.md
@@ -34,7 +34,7 @@ To set the webhook, go to [Slack Developer Console](https://api.slack.com/apps) 
 ## Idea of this example
 
 This example is a simple bot running on [Slack](https://slack.com/).
-For more information, check our [Slack guides](https://bottender.js.org/docs/Platforms-Slack).
+For more information, check our [Slack guides](https://bottender.js.org/docs/channel-slack-setup).
 
 ## Related examples
 

--- a/examples/slack-hello-world/README.md
+++ b/examples/slack-hello-world/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/slack-hello-world
 cd slack-hello-world
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken` and `verificationToken` into `index.js`.
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 

--- a/examples/slack-interactive-message/README.md
+++ b/examples/slack-interactive-message/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/slack-interactive-message
 cd slack-interactive-message
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken` and `verificationToken` into `index.js`.
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 

--- a/examples/slack-interactive-message/README.md
+++ b/examples/slack-interactive-message/README.md
@@ -35,7 +35,7 @@ To set the webhook, go to [Slack Developer Console](https://api.slack.com/apps) 
 
 This example shows how to send [messages with interactive components (button/menu)](https://api.slack.com/interactive-messages) and handle the event triggered by users clicking the button/menu.
 
-For more information, check our [Slack guides](https://bottender.js.org/docs/Platforms-Slack).
+For more information, check our [Slack guides](https://bottender.js.org/docs/channel-slack-setup).
 
 ## Usage
 

--- a/examples/telegram-hello-world/README.md
+++ b/examples/telegram-hello-world/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/telegram-hello-world
 cd telegram-hello-world
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken` into `bottender.config.js`.
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender telegram webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/telegram-hello-world/README.md
+++ b/examples/telegram-hello-world/README.md
@@ -29,10 +29,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender telegram webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender telegram webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `accessToken` into `bottender.config.js` before running this command.
@@ -40,7 +40,7 @@ bottender telegram webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 This example is a simple bot running on [Telegram](https://telegram.org/).
-For more information, check our [Telegram guides](https://bottender.js.org/docs/Platforms-Telegram).
+For more information, check our [Telegram guides](https://bottender.js.org/docs/channel-telegram-setup).
 
 ## Related examples
 

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/todos
 cd todos
 npm install

--- a/examples/viber-hello-world/README.md
+++ b/examples/viber-hello-world/README.md
@@ -29,10 +29,10 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 ## Set webhook
 
-While the server running, you can run following command with global `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
 ```
-bottender viber webhook set -w <YOUR_WEBHOOK_URL>
+npx bottender viber webhook set -w <YOUR_WEBHOOK_URL>
 ```
 
 > Note: You must put `accessToken` into `bottender.config.js` before running this command.
@@ -40,7 +40,7 @@ bottender viber webhook set -w <YOUR_WEBHOOK_URL>
 ## Idea of this example
 
 This example is a simple bot running on [Viber](https://www.viber.com/).
-For more information, check our [Viber guides](https://bottender.js.org/docs/Platforms-Viber).
+For more information, check our [Viber guides](https://bottender.js.org/docs/channel-viber-setup).
 
 ## Related examples
 

--- a/examples/viber-hello-world/README.md
+++ b/examples/viber-hello-world/README.md
@@ -4,14 +4,14 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/viber-hello-world
 cd viber-hello-world
 ```
 
 Install dependencies:
 
-```
+```sh
 npm install
 ```
 
@@ -19,7 +19,7 @@ You must put `accessToken` into `bottender.config.js`.
 
 After that, you can run the bot with this npm script:
 
-```
+```sh
 npm run dev
 ```
 
@@ -31,7 +31,7 @@ If you successfully start the server, you will get a webhook url like `https://x
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
-```
+```sh
 npx bottender viber webhook set -w <YOUR_WEBHOOK_URL>
 ```
 

--- a/examples/with-qna-maker/README.md
+++ b/examples/with-qna-maker/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [Bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/with-qna-maker
 cd with-qna-maker
 npm install

--- a/examples/with-state/README.md
+++ b/examples/with-state/README.md
@@ -4,7 +4,7 @@
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
-```
+```sh
 curl https://codeload.github.com/Yoctol/bottender/tar.gz/master | tar -xz --strip=2 bottender-master/examples/with-state
 cd with-state
 npm install
@@ -15,7 +15,7 @@ npm run dev --console
 
 This example shows how to use Session State to store some information from
 users. For more information, check our
-[session guide](https://bottender.js.org/docs/Guides-Session).
+[session guide](https://bottender.js.org/docs/the-basics-session).
 
 ## Related examples
 


### PR DESCRIPTION
- use `npx` instead of global `bottender`
- link to new setup guides
- use `sh` syntax