### PR TITLE
feat (slack): support slack block kits and view events

### DIFF
--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -139,8 +139,8 @@ export default class SlackConnector
     }
 
     // For slack modal
-    if (rawEvent.view && rawEvent.view.private_metadata) {
-      return JSON.parse(rawEvent.view.private_metadata).channelId;
+    if (rawEvent.view && rawEvent.view.privateMetadata) {
+      return JSON.parse(rawEvent.view.privateMetadata).channelId;
     }
 
     // For reaction_added format

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -138,6 +138,11 @@ export default class SlackConnector
       return rawEvent.channelId;
     }
 
+    // For slack modal
+    if (rawEvent.view && rawEvent.view.private_metadata) {
+      return JSON.parse(rawEvent.view.private_metadata).channelId;
+    }
+
     // For reaction_added format
     if (
       rawEvent.item &&
@@ -159,7 +164,9 @@ export default class SlackConnector
     let userFromBody;
     if (
       rawEvent.type === 'interactive_message' ||
-      rawEvent.type === 'block_actions'
+      rawEvent.type === 'block_actions' ||
+      rawEvent.type === 'view_submission' ||
+      rawEvent.type === 'view_closed'
     ) {
       userFromBody = rawEvent.user.id;
     } else {

--- a/packages/bottender/src/slack/SlackContext.ts
+++ b/packages/bottender/src/slack/SlackContext.ts
@@ -9,7 +9,7 @@ import Session from '../session/Session';
 import { PlatformContext } from '../context/PlatformContext';
 import { RequestContext } from '../types';
 
-import SlackEvent from './SlackEvent';
+import SlackEvent, { UIEvent } from './SlackEvent';
 
 type Options = {
   client: SlackOAuthClient;
@@ -373,7 +373,16 @@ export default class SlackContext extends Context<SlackOAuthClient, SlackEvent>
   _openView(options: SlackTypes.OpenViewOptions): Promise<any> {
     this._isHandled = true;
 
-    return this._client.views.open(options);
+    return this._client.views.open({
+      ...options,
+      view: {
+        ...options.view,
+        privateMetadata: JSON.stringify({
+          original: options.view.privateMetadata,
+          channelId: (this._event.rawEvent as UIEvent).channel.id,
+        }),
+      },
+    });
   }
 
   /**

--- a/packages/bottender/src/slack/SlackEvent.ts
+++ b/packages/bottender/src/slack/SlackEvent.ts
@@ -102,10 +102,15 @@ export type BlockActionEvent = UIEvent & {
   type: 'block_actions';
 };
 
+export type ViewEvent = UIEvent & {
+  type: 'view_submission' | 'view_closed';
+};
+
 export type SlackRawEvent =
   | Message
   | InteractiveMessageEvent
-  | BlockActionEvent;
+  | BlockActionEvent
+  | ViewEvent;
 
 export default class SlackEvent implements Event<SlackRawEvent> {
   _rawEvent: SlackRawEvent;
@@ -223,6 +228,22 @@ export default class SlackEvent implements Event<SlackRawEvent> {
    */
   get isBlockAction(): boolean {
     return this._rawEvent.type === 'block_actions';
+  }
+
+  /**
+   * Determine if the event is a view submission event.
+   *
+   */
+  get isViewSubmission(): boolean {
+    return this._rawEvent.type === 'view_submission';
+  }
+
+  /**
+   * Determine if the event is a view closed event.
+   *
+   */
+  get isViewClosed(): boolean {
+    return this._rawEvent.type === 'view_closed';
   }
 
   /**

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -100,6 +100,43 @@ const interactiveMessageRequest = {
   },
 };
 
+const viewSubmissionRequest = {
+  body: {
+    type: 'view_submission',
+    team: { id: 'T02RUPSBS', domain: 'yoctolinfo' },
+    user: {
+      id: 'UCL2D708M',
+      username: 'darkbtf',
+      name: 'darkbtf',
+      teamId: 'T02RUPSBS',
+    },
+    apiAppId: 'A604E7GSJ',
+    token: 'zBoHd4fjrvVcVuN9yTmlHMKC',
+    triggerId: '873508362498.2878808400.763026ca2acb11b3dfbcb85836d1c3d8',
+    view: {
+      id: 'VRQQ7JA4T',
+      teamId: 'T02RUPSBS',
+      type: 'modal',
+      blocks: [[Object]],
+      privateMetadata: '{"channelId":"C02ELGNBH"}',
+      callbackId: '截止',
+      state: { values: {} },
+      hash: '1577340522.d58ea69f',
+      title: { type: 'plain_text', text: '確認截止？', emoji: true },
+      clearOnClose: false,
+      notifyOnClose: false,
+      close: { type: 'plain_text', text: '取消', emoji: true },
+      submit: { type: 'plain_text', text: '送出 :boom:', emoji: true },
+      previousViewId: null,
+      rootViewId: 'VRQQ7JA4T',
+      appId: 'A604E7GSJ',
+      externalId: '',
+      appInstalledTeamId: 'T02RUPSBS',
+      botId: 'B618CBATV',
+    },
+  },
+};
+
 const RtmMessage = {
   type: 'message',
   channel: 'G7W5WAAAA',
@@ -182,6 +219,12 @@ describe('#getUniqueSessionKey', () => {
   it('extract correct channel id from pin_added event', () => {
     const { connector } = setup();
     const channelId = connector.getUniqueSessionKey(PinAddedRequest.body);
+    expect(channelId).toBe('C02ELGNBH');
+  });
+
+  it("extract correct channel id from view event's private_metadata", () => {
+    const { connector } = setup();
+    const channelId = connector.getUniqueSessionKey(viewSubmissionRequest.body);
     expect(channelId).toBe('C02ELGNBH');
   });
 });

--- a/packages/bottender/src/slack/__tests__/SlackContext.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackContext.spec.ts
@@ -483,7 +483,10 @@ describe('#views.open', () => {
 
     expect(client.views.open).toBeCalledWith({
       triggerId: '12345.98765.abcd2358fdea',
-      view: VIEW_PAYLOAD,
+      view: {
+        ...VIEW_PAYLOAD,
+        privateMetadata: '{"original":"Shh it is a secret"}',
+      },
     });
   });
 });


### PR DESCRIPTION
1. add all event types used by Slack block kits and Slack modal
2. use view.private_metadata to store channelId for bottender's session key