### PR TITLE
implement skipLegacyProfile for Telegram and Viber

### DIFF
--- a/packages/bottender/src/line/LineBot.ts
+++ b/packages/bottender/src/line/LineBot.ts
@@ -20,7 +20,7 @@ export default class LineBot extends Bot<
     mapDestinationToAccessToken,
     shouldBatch,
     sendMethod,
-    skipProfile,
+    skipLegacyProfile,
   }: {
     accessToken: string;
     channelSecret: string;
@@ -30,7 +30,7 @@ export default class LineBot extends Bot<
     shouldBatch?: boolean;
     sendMethod?: string;
     origin?: string;
-    skipProfile?: boolean;
+    skipLegacyProfile?: boolean;
   }) {
     const connector = new LineConnector({
       accessToken,
@@ -39,7 +39,7 @@ export default class LineBot extends Bot<
       shouldBatch,
       sendMethod,
       origin,
-      skipProfile,
+      skipLegacyProfile,
     });
     super({ connector, sessionStore, sync });
   }

--- a/packages/bottender/src/line/LineConnector.ts
+++ b/packages/bottender/src/line/LineConnector.ts
@@ -20,7 +20,7 @@ type CommonConstructorOptions = {
   mapDestinationToAccessToken?: (destination: string) => Promise<string>;
   shouldBatch?: boolean;
   sendMethod?: string;
-  skipProfile?: boolean;
+  skipLegacyProfile?: boolean;
 };
 
 type ConstructorOptionsWithoutClient = {
@@ -43,7 +43,7 @@ export default class LineConnector
 
   _channelSecret: string;
 
-  _skipProfile: boolean;
+  _skipLegacyProfile: boolean;
 
   _mapDestinationToAccessToken:
     | ((destination: string) => Promise<string>)
@@ -58,7 +58,7 @@ export default class LineConnector
       mapDestinationToAccessToken,
       shouldBatch,
       sendMethod,
-      skipProfile,
+      skipLegacyProfile,
     } = options;
     if ('client' in options) {
       this._client = options.client;
@@ -85,8 +85,8 @@ export default class LineConnector
     );
     this._sendMethod = sendMethod || 'reply';
 
-    // FIXME: maybe set this default value as true
-    this._skipProfile = typeof skipProfile === 'boolean' ? skipProfile : false;
+    this._skipLegacyProfile =
+      typeof skipLegacyProfile === 'boolean' ? skipLegacyProfile : true;
   }
 
   _isWebhookVerifyEvent(event: LineRawEvent): boolean {
@@ -140,7 +140,7 @@ export default class LineConnector
       let user = null;
 
       if (source.userId) {
-        user = this._skipProfile
+        user = this._skipLegacyProfile
           ? {
               id: source.userId,
               _updatedAt: new Date().toISOString(),
@@ -176,7 +176,7 @@ export default class LineConnector
       let user = null;
 
       if (source.userId) {
-        user = this._skipProfile
+        user = this._skipLegacyProfile
           ? {
               id: source.userId,
               _updatedAt: new Date().toISOString(),
@@ -210,7 +210,7 @@ export default class LineConnector
       };
     } else if (source.type === 'user') {
       if (!session.user) {
-        const user = this._skipProfile
+        const user = this._skipLegacyProfile
           ? {}
           : await this._client.getUserProfile(source.userId);
 

--- a/packages/bottender/src/line/__tests__/LineConnector.spec.ts
+++ b/packages/bottender/src/line/__tests__/LineConnector.spec.ts
@@ -82,7 +82,7 @@ const webhookVerifyRequest = {
   },
 };
 
-function setup({ sendMethod, skipProfile } = {}) {
+function setup({ sendMethod, skipLegacyProfile } = {}) {
   const mockLineAPIClient = {
     getUserProfile: jest.fn(),
     isValidSignature: jest.fn(),
@@ -99,7 +99,7 @@ function setup({ sendMethod, skipProfile } = {}) {
       accessToken: ACCESS_TOKEN,
       channelSecret: CHANNEL_SECRET,
       sendMethod,
-      skipProfile,
+      skipLegacyProfile,
     }),
   };
 }
@@ -209,7 +209,9 @@ describe('#getUniqueSessionKey', () => {
 
 describe('#updateSession', () => {
   it('update session with data needed', async () => {
-    const { connector, mockLineAPIClient } = setup();
+    const { connector, mockLineAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const user = {
       id: 'U206d25c2ea6bd87c17655609a1c37cb8',
       displayName: 'LINE taro',
@@ -242,7 +244,9 @@ describe('#updateSession', () => {
   });
 
   it('update session if session.user exists', async () => {
-    const { connector, mockLineAPIClient } = setup();
+    const { connector, mockLineAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const user = {
       id: 'U206d25c2ea6bd87c17655609a1c37cb8',
       displayName: 'LINE taro',
@@ -271,7 +275,9 @@ describe('#updateSession', () => {
   });
 
   it('update session with group type message', async () => {
-    const { connector, mockLineAPIClient } = setup();
+    const { connector, mockLineAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const body = {
       events: [
         {
@@ -343,7 +349,9 @@ describe('#updateSession', () => {
   });
 
   it('update session with group type event without userId', async () => {
-    const { connector, mockLineAPIClient } = setup();
+    const { connector, mockLineAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const body = {
       events: [
         {
@@ -398,7 +406,9 @@ describe('#updateSession', () => {
   });
 
   it('update session with room type message', async () => {
-    const { connector, mockLineAPIClient } = setup();
+    const { connector, mockLineAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const body = {
       events: [
         {
@@ -470,7 +480,9 @@ describe('#updateSession', () => {
   });
 
   it('update session with room type event without userId', async () => {
-    const { connector, mockLineAPIClient } = setup();
+    const { connector, mockLineAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const body = {
       events: [
         {
@@ -525,7 +537,9 @@ describe('#updateSession', () => {
   });
 
   it('update session with other type message', async () => {
-    const { connector } = setup();
+    const { connector } = setup({
+      skipLegacyProfile: false,
+    });
     const body = {
       events: [
         {
@@ -559,8 +573,8 @@ describe('#updateSession', () => {
     });
   });
 
-  it('update userId without calling any api while skipProfile setted true', async () => {
-    const { connector, mockLineAPIClient } = setup({ skipProfile: true });
+  it('update userId without calling any api while skipLegacyProfile set to true', async () => {
+    const { connector, mockLineAPIClient } = setup();
     const session = {};
 
     await connector.updateSession(session, request.body);

--- a/packages/bottender/src/messenger/MessengerBot.ts
+++ b/packages/bottender/src/messenger/MessengerBot.ts
@@ -22,7 +22,7 @@ export default class MessengerBot extends Bot<
     batchConfig,
     origin,
     skipAppSecretProof,
-    skipProfile,
+    skipLegacyProfile,
   }: {
     accessToken: string;
     appId: string;
@@ -34,7 +34,7 @@ export default class MessengerBot extends Bot<
     batchConfig?: Record<string, any>;
     origin?: string;
     skipAppSecretProof?: boolean;
-    skipProfile?: boolean;
+    skipLegacyProfile?: boolean;
   }) {
     const connector = new MessengerConnector({
       accessToken,
@@ -45,7 +45,7 @@ export default class MessengerBot extends Bot<
       batchConfig,
       origin,
       skipAppSecretProof,
-      skipProfile,
+      skipLegacyProfile,
     });
     super({ connector, sessionStore, sync });
   }

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -81,7 +81,7 @@ type CommonConstructorOptions = {
   appSecret: string;
   verifyToken?: string;
   batchConfig?: Record<string, any>;
-  skipProfile?: boolean;
+  skipLegacyProfile?: boolean;
   mapPageToAccessToken?: (pageId: string) => Promise<string>;
 };
 
@@ -107,7 +107,7 @@ export default class MessengerConnector
 
   _appSecret: string;
 
-  _skipProfile: boolean;
+  _skipLegacyProfile: boolean;
 
   _mapPageToAccessToken: ((pageId: string) => Promise<string>) | null = null;
 
@@ -125,7 +125,7 @@ export default class MessengerConnector
       verifyToken,
       batchConfig,
 
-      skipProfile,
+      skipLegacyProfile,
     } = options;
 
     if ('client' in options) {
@@ -146,8 +146,8 @@ export default class MessengerConnector
     this._mapPageToAccessToken = mapPageToAccessToken || null;
     this._verifyToken = verifyToken || shortid.generate();
 
-    // FIXME: maybe set this default value as true
-    this._skipProfile = typeof skipProfile === 'boolean' ? skipProfile : false;
+    this._skipLegacyProfile =
+      typeof skipLegacyProfile === 'boolean' ? skipLegacyProfile : true;
 
     this._batchConfig = batchConfig || null;
     if (this._batchConfig) {
@@ -273,7 +273,7 @@ export default class MessengerConnector
       }
 
       // FIXME: refine user
-      if (this._skipProfile) {
+      if (this._skipLegacyProfile) {
         session.user = {
           _updatedAt: new Date().toISOString(),
           id: senderId,

--- a/packages/bottender/src/messenger/__tests__/MessengerConnector.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/MessengerConnector.spec.ts
@@ -163,15 +163,13 @@ const webhookTestRequest = {
   },
 };
 
-function setup(
-  { accessToken, appSecret, mapPageToAccessToken, verifyToken, skipProfile } = {
-    accessToken: ACCESS_TOKEN,
-    appSecret: APP_SECRET,
-    mapPageToAccessToken: jest.fn(),
-    verifyToken: '1qaz2wsx',
-    skipProfile: false,
-  }
-) {
+function setup({
+  accessToken = ACCESS_TOKEN,
+  appSecret = APP_SECRET,
+  mapPageToAccessToken = jest.fn(),
+  verifyToken = '1qaz2wsx',
+  skipLegacyProfile = true,
+} = {}) {
   const mockGraphAPIClient = {
     getUserProfile: jest.fn(),
   };
@@ -184,7 +182,7 @@ function setup(
       appSecret,
       mapPageToAccessToken,
       verifyToken,
-      skipProfile,
+      skipLegacyProfile,
     }),
   };
 }
@@ -266,7 +264,9 @@ describe('#getUniqueSessionKey', () => {
 
 describe('#updateSession', () => {
   it('update session with data needed', async () => {
-    const { connector, mockGraphAPIClient } = setup();
+    const { connector, mockGraphAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const user = {
       id: '1412611362105802',
       firstName: 'firstName',
@@ -298,7 +298,9 @@ describe('#updateSession', () => {
   });
 
   it('update session when profilePic expired', async () => {
-    const { connector, mockGraphAPIClient } = setup();
+    const { connector, mockGraphAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const user = {
       id: '1412611362105802',
       firstName: 'firstName',
@@ -334,7 +336,9 @@ describe('#updateSession', () => {
   });
 
   it('update session when expired date is invalid', async () => {
-    const { connector, mockGraphAPIClient } = setup();
+    const { connector, mockGraphAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const user = {
       id: '1412611362105802',
       firstName: 'firstName',
@@ -370,7 +374,9 @@ describe('#updateSession', () => {
   });
 
   it('update session when something wrong', async () => {
-    const { connector, mockGraphAPIClient } = setup();
+    const { connector, mockGraphAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const user = {
       id: '1412611362105802',
       firstName: 'firstName',
@@ -406,7 +412,9 @@ describe('#updateSession', () => {
   });
 
   it('update session when getUserProfile() failed', async () => {
-    const { connector, mockGraphAPIClient } = setup();
+    const { connector, mockGraphAPIClient } = setup({
+      skipLegacyProfile: false,
+    });
     const error = new Error('fail');
 
     mockGraphAPIClient.getUserProfile.mockRejectedValue(error);
@@ -435,9 +443,9 @@ describe('#updateSession', () => {
     expect(console.error).toBeCalledWith(error);
   });
 
-  it(`update session without gettiing user's profile when skipProfile setted true`, async () => {
+  it(`update session without getting user's profile when skipLegacyProfile set to true`, async () => {
     const { connector, mockGraphAPIClient } = setup({
-      skipProfile: true,
+      skipLegacyProfile: true,
     });
 
     const session = {};

--- a/packages/bottender/src/slack/SlackBot.ts
+++ b/packages/bottender/src/slack/SlackBot.ts
@@ -20,20 +20,20 @@ export default class SlackBot extends Bot<
     sync,
     verificationToken,
     origin,
-    skipProfile,
+    skipLegacyProfile,
   }: {
     accessToken: string;
     sessionStore: SessionStore;
     sync?: boolean;
     verificationToken?: string;
     origin?: string;
-    skipProfile?: boolean | null;
+    skipLegacyProfile?: boolean | null;
   }) {
     const connector = new SlackConnector({
       accessToken,
       verificationToken,
       origin,
-      skipProfile,
+      skipLegacyProfile,
     });
     super({ connector, sessionStore, sync });
     this._accessToken = accessToken;

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -37,7 +37,7 @@ type EventsAPIBody = {
 export type SlackRequestBody = EventsAPIBody | { payload: string };
 
 type CommonConstructorOptions = {
-  skipProfile?: boolean | null;
+  skipLegacyProfile?: boolean | null;
   verificationToken?: string;
 };
 
@@ -60,10 +60,10 @@ export default class SlackConnector
 
   _verificationToken: string;
 
-  _skipProfile: boolean;
+  _skipLegacyProfile: boolean;
 
   constructor(options: ConstructorOptions) {
-    const { verificationToken, skipProfile } = options;
+    const { verificationToken, skipLegacyProfile } = options;
     if ('client' in options) {
       this._client = options.client;
     } else {
@@ -76,8 +76,8 @@ export default class SlackConnector
 
     this._verificationToken = verificationToken || '';
 
-    // FIXME: maybe set this default value as true
-    this._skipProfile = typeof skipProfile === 'boolean' ? skipProfile : false;
+    this._skipLegacyProfile =
+      typeof skipLegacyProfile === 'boolean' ? skipLegacyProfile : true;
 
     if (!this._verificationToken) {
       warning(
@@ -181,7 +181,7 @@ export default class SlackConnector
       return;
     }
 
-    if (this._skipProfile) {
+    if (this._skipLegacyProfile) {
       session.user = {
         id: senderId,
         _updatedAt: new Date().toISOString(),

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -112,7 +112,7 @@ const RtmMessage = {
 
 function setup({
   verificationToken = 'xxxxxxxxxxxxxxxxxxxxxxxxxxx',
-  skipProfile,
+  skipLegacyProfile,
 } = {}) {
   const mockSlackOAuthClient = {
     getUserInfo: jest.fn(),
@@ -126,7 +126,7 @@ function setup({
     connector: new SlackConnector({
       accessToken,
       verificationToken,
-      skipProfile,
+      skipLegacyProfile,
     }),
     mockSlackOAuthClient,
   };
@@ -188,7 +188,9 @@ describe('#getUniqueSessionKey', () => {
 
 describe('#updateSession', () => {
   it('update session with data needed', async () => {
-    const { connector, mockSlackOAuthClient } = setup();
+    const { connector, mockSlackOAuthClient } = setup({
+      skipLegacyProfile: false,
+    });
 
     const user = {
       id: 'U13A00000',
@@ -229,7 +231,9 @@ describe('#updateSession', () => {
   });
 
   it('not update session if it is bot event request', async () => {
-    const { connector, mockSlackOAuthClient } = setup();
+    const { connector, mockSlackOAuthClient } = setup({
+      skipLegacyProfile: false,
+    });
 
     const session = {};
 
@@ -243,7 +247,9 @@ describe('#updateSession', () => {
   });
 
   it('not update session if no senderId in body', async () => {
-    const { connector, mockSlackOAuthClient } = setup();
+    const { connector, mockSlackOAuthClient } = setup({
+      skipLegacyProfile: false,
+    });
 
     const session = {};
     const body = {
@@ -273,7 +279,9 @@ describe('#updateSession', () => {
   });
 
   it('update session with data needed when receiving interactive message request', async () => {
-    const { connector, mockSlackOAuthClient } = setup();
+    const { connector, mockSlackOAuthClient } = setup({
+      skipLegacyProfile: false,
+    });
 
     const user = {
       id: 'U056K3CN1',
@@ -313,8 +321,8 @@ describe('#updateSession', () => {
     });
   });
 
-  it('update session without calling apis while skipProfile setted true', async () => {
-    const { connector, mockSlackOAuthClient } = setup({ skipProfile: true });
+  it('update session without calling apis while skipLegacyProfile set true', async () => {
+    const { connector, mockSlackOAuthClient } = setup();
 
     const session = {};
 

--- a/packages/bottender/src/telegram/__tests__/TelegramConnector.spec.ts
+++ b/packages/bottender/src/telegram/__tests__/TelegramConnector.spec.ts
@@ -293,7 +293,10 @@ function setup() {
   TelegramClient.connect.mockReturnValue(mockTelegramClient);
   return {
     mockTelegramClient,
-    connector: new TelegramConnector({ accessToken: ACCESS_TOKEN }),
+    connector: new TelegramConnector({
+      accessToken: ACCESS_TOKEN,
+      skipLegacyProfile: false,
+    }),
   };
 }
 

--- a/packages/bottender/src/viber/__tests__/ViberConnector.spec.ts
+++ b/packages/bottender/src/viber/__tests__/ViberConnector.spec.ts
@@ -114,6 +114,7 @@ function setup() {
     connector: new ViberConnector({
       accessToken: ACCESS_TOKEN,
       sender: { name: 'sender' },
+      skipLegacyProfile: false,
     }),
   };
 }


### PR DESCRIPTION
- rename `skipProfile` to `skipLegacyProfile` and set to true by default
- implement `skipLegacyProfile` for Telegram and Viber