### PR TITLE
chore: rename debug bottender:dialog to bottender:action

### DIFF
--- a/docs/the-basics-actions.md
+++ b/docs/the-basics-actions.md
@@ -72,22 +72,22 @@ Bottender will call the `SayHi` action with `{ name: 'Bob' }` as the `props` and
 
 ## How to Debug
 
-Bottender use famous [debug](https://www.npmjs.com/package/debug) package internally to collect some helpful information that can be showed up when you provide corresponding `DEBUG` environment variable. To debug your actions, you may run your command with `DEBUG=bottender:dialog`, for example:
+Bottender use famous [debug](https://www.npmjs.com/package/debug) package internally to collect some helpful information that can be showed up when you provide corresponding `DEBUG` environment variable. To debug your actions, you may run your command with `DEBUG=bottender:action`, for example:
 
 ```sh
-DEBUG=bottender:dialog npm start
+DEBUG=bottender:action npm start
 ```
 
 > **Note:** If you are developing your bots on Windows, you may use [cross-env](https://www.npmjs.com/package/cross-env) to assign `DEBUG` environment variable:
 
 ```sh
-cross-env DEBUG=bottender:dialog npm start
+cross-env DEBUG=bottender:action npm start
 ```
 
 Or you may put your `DEBUG` environment setting into your `.env` file:
 
 ```
-DEBUG=bottender:dialog
+DEBUG=bottender:action
 ```
 
 ![](https://user-images.githubusercontent.com/3382565/67746734-0cccd400-fa62-11e9-9318-3517a983eb64.png)

--- a/packages/bottender/src/bot/Bot.ts
+++ b/packages/bottender/src/bot/Bot.ts
@@ -30,7 +30,7 @@ const debugRequest = debug('bottender:request');
 const debugResponse = debug('bottender:response');
 const debugSessionRead = debug('bottender:session:read');
 const debugSessionWrite = debug('bottender:session:write');
-const debugDialog = debug('bottender:dialog');
+const debugAction = debug('bottender:action');
 
 const MINUTES_IN_ONE_YEAR = 365 * 24 * 60;
 
@@ -49,13 +49,13 @@ export function run<C extends Client, E extends Event>(
     let nextDialog: Action<C, E> | void = action;
 
     // TODO: refactor this with withProps or whatever
-    debugDialog(`Current Dialog: ${nextDialog.name || 'Anonymous'}`);
+    debugAction(`Current Dialog: ${nextDialog.name || 'Anonymous'}`);
     // eslint-disable-next-line no-await-in-loop
     nextDialog = await nextDialog(context, props);
 
     while (typeof nextDialog === 'function') {
       // TODO: improve this debug helper
-      debugDialog(`Current Dialog: ${nextDialog.name || 'Anonymous'}`);
+      debugAction(`Current Dialog: ${nextDialog.name || 'Anonymous'}`);
       // eslint-disable-next-line no-await-in-loop
       nextDialog = await nextDialog(context, {});
     }


### PR DESCRIPTION
Replacing

```
DEBUG=bottender:dialog
```

to

```
DEBUG=bottender:action
```

`dialog` is a legacy keyword in our system and should be replaced by `action`.