### PR TITLE
feat(messenger): add fields support to context.getUserProfile()

### DIFF
--- a/packages/bottender/package.json
+++ b/packages/bottender/package.json
@@ -50,7 +50,7 @@
     "lru-cache": "^5.1.1",
     "messaging-api-common": "^1.0.0-beta.5",
     "messaging-api-line": "^1.0.0-beta.5",
-    "messaging-api-messenger": "^1.0.0-beta.5",
+    "messaging-api-messenger": "^1.0.0-beta.10",
     "messaging-api-slack": "^1.0.0-beta.5",
     "messaging-api-telegram": "^1.0.0-beta.5",
     "messaging-api-viber": "^1.0.0-beta.2",

--- a/packages/bottender/src/messenger/MessengerContext.ts
+++ b/packages/bottender/src/messenger/MessengerContext.ts
@@ -3,7 +3,11 @@ import EventEmitter from 'events';
 import invariant from 'invariant';
 import sleep from 'delay';
 import warning from 'warning';
-import { MessengerBatch, MessengerClient } from 'messaging-api-messenger';
+import {
+  MessengerBatch,
+  MessengerClient,
+  MessengerTypes,
+} from 'messaging-api-messenger';
 
 import Context from '../context/Context';
 import Session from '../session/Session';
@@ -142,16 +146,9 @@ class MessengerContext extends Context<MessengerClient, MessengerEvent>
     return this._callClientMethod('sendText', args);
   }
 
-  /**
-   * Sender Actions
-   *
-   * https://github.com/Yoctol/messaging-apis/tree/master/packages/messaging-api-messenger#sender-actions
-   */
-
-  /**
-   * https://github.com/Yoctol/messaging-apis/tree/master/packages/messaging-api-messenger#typingonuserid
-   */
-  async getUserProfile(): Promise<Record<string, any> | null> {
+  async getUserProfile(options: {
+    fields?: MessengerTypes.UserProfileField[];
+  }): Promise<MessengerTypes.User | null> {
     if (!this._session) {
       warning(
         false,
@@ -166,6 +163,7 @@ class MessengerContext extends Context<MessengerClient, MessengerEvent>
         ...(this._customAccessToken
           ? { accessToken: this._customAccessToken }
           : undefined),
+        ...options,
       },
     ];
 
@@ -182,7 +180,7 @@ class MessengerContext extends Context<MessengerClient, MessengerEvent>
    * https://github.com/Yoctol/messaging-apis/tree/master/packages/messaging-api-messenger#sendsenderactionuserid-action
    */
   async sendSenderAction(
-    action: string,
+    senderAction: MessengerTypes.SenderAction,
     options?: Record<string, any>
   ): Promise<any> {
     if (!this._session) {
@@ -197,7 +195,7 @@ class MessengerContext extends Context<MessengerClient, MessengerEvent>
 
     const args = [
       this._session.user.id,
-      action,
+      senderAction,
       {
         ...(this._customAccessToken
           ? { accessToken: this._customAccessToken }

--- a/packages/bottender/src/messenger/__tests__/MessengerContext.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/MessengerContext.spec.ts
@@ -89,12 +89,11 @@ describe('#getUserProfile', () => {
     const { context, client, session } = setup();
 
     const user = {
+      id: session.user.id,
+      name: 'Kevin Durant',
       firstName: 'Kevin',
       lastName: 'Durant',
       profilePic: 'https://example.com/pic.png',
-      locale: 'en_US',
-      timezone: 8,
-      gender: 'male',
     };
 
     client.getUserProfile.mockResolvedValue(user);
@@ -107,6 +106,51 @@ describe('#getUserProfile', () => {
     expect(result).toEqual(user);
   });
 
+  it('should call client with custom fields', async () => {
+    const { context, client, session } = setup();
+
+    const user = {
+      id: session.user.id,
+      name: 'Kevin Durant',
+      firstName: 'Kevin',
+      lastName: 'Durant',
+      profilePic: 'https://example.com/pic.png',
+      locale: 'en_US',
+      timezone: 8,
+      gender: 'male',
+    };
+
+    client.getUserProfile.mockResolvedValue(user);
+
+    const result = await context.getUserProfile({
+      fields: [
+        'id',
+        'name',
+        'first_name',
+        'last_name',
+        'profile_pic',
+        'locale',
+        'timezone',
+        'gender',
+      ],
+    });
+
+    expect(client.getUserProfile).toBeCalledWith(session.user.id, {
+      fields: [
+        'id',
+        'name',
+        'first_name',
+        'last_name',
+        'profile_pic',
+        'locale',
+        'timezone',
+        'gender',
+      ],
+      accessToken: undefined,
+    });
+    expect(result).toEqual(user);
+  });
+
   it('should use custom access token', async () => {
     const { context, client, session } = setup({
       session: userSession,
@@ -114,12 +158,11 @@ describe('#getUserProfile', () => {
     });
 
     const user = {
+      id: session.user.id,
+      name: 'Kevin Durant',
       firstName: 'Kevin',
       lastName: 'Durant',
       profilePic: 'https://example.com/pic.png',
-      locale: 'en_US',
-      timezone: 8,
-      gender: 'male',
     };
 
     client.getUserProfile.mockResolvedValue(user);

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,7 +139,7 @@
     to-fast-properties "^2.0.0"
 
 "@bottender/express@file:packages/bottender-express":
-  version "1.0.0-beta.3"
+  version "1.0.0"
   dependencies:
     body-parser "^1.19.0"
     express "^4.17.1"
@@ -6786,10 +6786,10 @@ messaging-api-line@^1.0.0-beta.5:
     messaging-api-common "^1.0.0-beta.5"
     warning "^4.0.3"
 
-messaging-api-messenger@^1.0.0-beta.5:
-  version "1.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/messaging-api-messenger/-/messaging-api-messenger-1.0.0-beta.5.tgz#3c4f6c396c2391faa3427293a798f62063496c42"
-  integrity sha512-UGqvVzvShIyETY+w3iOMMpqkNs+jt3hB2MFVtqekeOMZUjVpQ3SYI0cnbs89zEisMCiGPNU5MrIWy/xtDd0fsg==
+messaging-api-messenger@^1.0.0-beta.10:
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/messaging-api-messenger/-/messaging-api-messenger-1.0.0-beta.10.tgz#ced74a88af54b5a0d0e09d383692401257a988f8"
+  integrity sha512-y0Mi0OneGPS1MsjtI6rRUNVYuJtcvDWjJI+E0zd3EVHS79B6/DSPVkK10FsCRe0VyzM/P9RhSaNyMgVt1s9Aqw==
   dependencies:
     append-query "^2.1.0"
     axios "^0.19.0"


### PR DESCRIPTION
After merging this, we can assign particular fields to fetch when calling `context.getUserProfile()`:

```js
const result = await context.getUserProfile({
  fields: [
    'id',
    'name',
    'first_name',
    'last_name',
    'profile_pic',
    'locale',
    'timezone',
    'gender',
  ],
});
```

This provides the ability to solve #395

