### PR TITLE
fix(line): set shouldBatch to false after handlerDidEnd has been called

### DIFF
--- a/packages/bottender/src/line/LineContext.ts
+++ b/packages/bottender/src/line/LineContext.ts
@@ -93,6 +93,9 @@ class LineContext extends Context<LineClient, LineEvent>
    */
   async handlerDidEnd() {
     if (this._shouldBatch) {
+      // After starting this batch, every api should be called out of batch mode
+      this._shouldBatch = false;
+
       if (this._replyMessages.length > 0) {
         const messageChunks = chunk(this._replyMessages, 5);
         warning(

--- a/packages/bottender/src/line/__tests__/LineContext.spec.ts
+++ b/packages/bottender/src/line/__tests__/LineContext.spec.ts
@@ -1885,6 +1885,53 @@ describe('batch', () => {
     );
     expect(warning).not.toBeCalled();
   });
+
+  it('should not batch after handlerDidEnd has been called', async () => {
+    const { client, context, session } = setup({ shouldBatch: true });
+
+    await context.replyText('1');
+    await context.pushText('2');
+    await context.pushText('3');
+
+    await context.handlerDidEnd();
+
+    await context.pushText('4');
+
+    expect(client.reply).toBeCalledWith(
+      REPLY_TOKEN,
+      [
+        {
+          type: 'text',
+          text: '1',
+        },
+      ],
+      { accessToken: undefined }
+    );
+    expect(client.push).toBeCalledWith(
+      session.user.id,
+      [
+        {
+          type: 'text',
+          text: '2',
+        },
+        {
+          type: 'text',
+          text: '3',
+        },
+      ],
+      { accessToken: undefined }
+    );
+    expect(client.push).toBeCalledWith(
+      session.user.id,
+      [
+        {
+          type: 'text',
+          text: '4',
+        },
+      ],
+      { accessToken: undefined }
+    );
+  });
 });
 
 describe('sendMethod', () => {


### PR DESCRIPTION
fix #525

This may be the best way to handle errors in LINE:

```js
module.exports = async function HandleError(context, props) {
  if (process.env.NODE_ENV === 'development') {
    await context.pushText('There are some unexpected errors happened. Please try again later, sorry for the inconvenience.');
    await context.pushText(props.error.stack);
  } else if (!context.isReplied) {
    await context.replyText('There are some unexpected errors happened. Please try again later, sorry for the inconvenience.'
  }
  if (process.env.NODE_ENV === 'production') {
    // send your error to the error tracker, for example: Sentry
  }
};
```