### PR TITLE
add altText to document sample

### DIFF
--- a/docs/channel-line-flex.md
+++ b/docs/channel-line-flex.md
@@ -32,7 +32,7 @@ To send flex messages, call `context.sendFlex()` with your flex content:
 
 ```js
 async function App(context) {
-  await context.sendFlex({
+  await context.sendFlex('BasicSample', {
     type: 'bubble',
     body: {
       type: 'box',
@@ -60,7 +60,7 @@ Let's see a much more complicated example. This example offers a better user exp
 
 ```js
 async function App(context) {
-  await context.sendFlex({
+  await context.sendFlex('AdvancedSample', {
     type: 'bubble',
     hero: {
       type: 'image',
@@ -142,7 +142,7 @@ async function App(context) {
     type: 'bubble',
     // ...other attributes
   };
-  await context.sendFlex({
+  await context.sendFlex('CarouselSample', {
     type: 'carousel',
     contents: [
       // put multiple bubbles in your carousel

--- a/website/versioned_docs/version-1.0.0/channel-line-flex.md
+++ b/website/versioned_docs/version-1.0.0/channel-line-flex.md
@@ -33,7 +33,7 @@ To send flex messages, call `context.sendFlex()` with your flex content:
 
 ```js
 async function App(context) {
-  await context.sendFlex({
+  await context.sendFlex('BasicSample', {
     type: 'bubble',
     body: {
       type: 'box',
@@ -61,7 +61,7 @@ Let's see a much more complicated example. This example offers a better user exp
 
 ```js
 async function App(context) {
-  await context.sendFlex({
+  await context.sendFlex('AdvancedSample', {
     type: 'bubble',
     hero: {
       type: 'image',
@@ -143,7 +143,7 @@ async function App(context) {
     type: 'bubble',
     // ...other attributes
   };
-  await context.sendFlex({
+  await context.sendFlex('CarouselSample', {
     type: 'carousel',
     contents: [
       // put multiple bubbles in your carousel


### PR DESCRIPTION
This image is my test sendFlex's error log:
![](https://i.imgur.com/gyXF034.png)

> Sample code is referenced by [official  doc](https://bottender.js.org/docs/channel-line-flex)

```javascript
async function App(context) {
  await context.sendFlex({
    type: 'bubble',
    body: {
      type: 'box',
      layout: 'horizontal',
      contents: [
        {
          type: 'text',
          text: 'Hello,',
        },
        {
          type: 'text',
          text: 'World!',
        },
      ],
    },
  });
}
```

I found `sendFlex()` has `altText` parameter,
so I add sample text in documents😆