### PR TITLE
feat(session): use Windows safe key seperator for file session

### DIFF
--- a/packages/bottender/src/session/FileSessionStore.ts
+++ b/packages/bottender/src/session/FileSessionStore.ts
@@ -1,3 +1,5 @@
+import os from 'os';
+
 import JFSStore, { Instance } from 'jfs';
 import isBefore from 'date-fns/isBefore';
 import subMinutes from 'date-fns/subMinutes';
@@ -44,9 +46,11 @@ export default class FileSessionStore implements SessionStore {
   }
 
   async read(key: string): Promise<Session | null> {
+    const safeKey = os.platform() === 'win32' ? key.replace(':', '@') : key;
+
     try {
       const session: Session | null = await new Promise((resolve, reject) => {
-        this._jfs.get(key, (err, obj) => {
+        this._jfs.get(safeKey, (err, obj) => {
           if (err) {
             reject(err);
           } else {
@@ -78,10 +82,12 @@ export default class FileSessionStore implements SessionStore {
   }
 
   async write(key: string, sess: Session): Promise<void> {
+    const safeKey = os.platform() === 'win32' ? key.replace(':', '@') : key;
+
     sess.lastActivity = Date.now();
 
     await new Promise((resolve, reject) => {
-      this._jfs.save(key, sess, err => {
+      this._jfs.save(safeKey, sess, err => {
         if (err) {
           reject(err);
         } else {
@@ -92,8 +98,10 @@ export default class FileSessionStore implements SessionStore {
   }
 
   async destroy(key: string): Promise<void> {
+    const safeKey = os.platform() === 'win32' ? key.replace(':', '@') : key;
+
     return new Promise((resolve, reject) => {
-      this._jfs.delete(key, err => {
+      this._jfs.delete(safeKey, err => {
         if (err) {
           reject(err);
         } else {

--- a/packages/bottender/src/session/__tests__/FileSessionStore.spec.ts
+++ b/packages/bottender/src/session/__tests__/FileSessionStore.spec.ts
@@ -1,8 +1,12 @@
+import os from 'os';
+
 import subMinutes from 'date-fns/subMinutes';
 
 import FileSessionStore from '../FileSessionStore';
 
 const expiresIn = 10;
+
+const KEY_SEPARATOR = os.platform() === 'win32' ? '@' : ':';
 
 function setup() {
   const store = new FileSessionStore('.session', expiresIn);
@@ -40,7 +44,10 @@ describe('#read', () => {
     jfs.get.mockImplementation((_, cb) => cb(null, { x: 1 }));
 
     expect(await store.read('yoctol:1')).toEqual({ x: 1 });
-    expect(jfs.get).toBeCalledWith('yoctol:1', expect.any(Function));
+    expect(jfs.get).toBeCalledWith(
+      `yoctol${KEY_SEPARATOR}1`,
+      expect.any(Function)
+    );
   });
 
   it('should return null when jfs throw error', async () => {
@@ -50,7 +57,10 @@ describe('#read', () => {
     jfs.get.mockImplementation((_, cb) => cb(new Error()));
 
     expect(await store.read('yoctol:1')).toBeNull();
-    expect(jfs.get).toBeCalledWith('yoctol:1', expect.any(Function));
+    expect(jfs.get).toBeCalledWith(
+      `yoctol${KEY_SEPARATOR}1`,
+      expect.any(Function)
+    );
   });
 
   it('should return null when session expires', async () => {
@@ -61,7 +71,10 @@ describe('#read', () => {
     jfs.get.mockImplementation((_, cb) => cb(null, sess));
 
     expect(await store.read('yoctol:1')).toBeNull();
-    expect(jfs.get).toBeCalledWith('yoctol:1', expect.any(Function));
+    expect(jfs.get).toBeCalledWith(
+      `yoctol${KEY_SEPARATOR}1`,
+      expect.any(Function)
+    );
   });
 });
 
@@ -98,7 +111,11 @@ describe('#write', () => {
 
     await store.write('yoctol:1', sess);
 
-    expect(jfs.save).toBeCalledWith('yoctol:1', sess, expect.any(Function));
+    expect(jfs.save).toBeCalledWith(
+      `yoctol${KEY_SEPARATOR}1`,
+      sess,
+      expect.any(Function)
+    );
   });
 });
 
@@ -111,6 +128,9 @@ describe('#destroy', () => {
 
     await store.destroy('yoctol:1');
 
-    expect(jfs.delete).toBeCalledWith('yoctol:1', expect.any(Function));
+    expect(jfs.delete).toBeCalledWith(
+      `yoctol${KEY_SEPARATOR}1`,
+      expect.any(Function)
+    );
   });
 });


### PR DESCRIPTION
After some discussion, we decide to use safe separator in only when the developer develop on windows and use the file session.

This should be backward capable and breaks minimal implement and fix #413 

Also, close #481 