### PR TITLE
fix(browser-only): let BrowserContext extends Context

### DIFF
--- a/examples/browser-only/README.md
+++ b/examples/browser-only/README.md
@@ -11,6 +11,8 @@ npm install
 npm run start
 ```
 
+![](https://user-images.githubusercontent.com/3382565/71249572-75487b00-2358-11ea-90a3-f4fdbd6dd4bb.gif)
+
 ## Idea of this example
 
 This example is a simple bot running on your browser.

--- a/examples/browser-only/package.json
+++ b/examples/browser-only/package.json
@@ -7,12 +7,12 @@
     "start": "react-scripts start"
   },
   "dependencies": {
-    "@chentsulin/react-botui": "^0.1.2",
+    "@chentsulin/react-botui": "^0.2.1",
     "bottender": "next",
     "botui": "^0.3.9",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0",
-    "react-scripts": "3.2.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-scripts": "3.3.0"
   },
   "browserslist": [
     ">0.2%",

--- a/examples/browser-only/src/BottenderApp.js
+++ b/examples/browser-only/src/BottenderApp.js
@@ -1,3 +1,4 @@
 export default async function App(context) {
   await context.sendText('Hello World');
+  await context.sendText(`Received: ${context.event.text}`);
 }

--- a/examples/browser-only/src/BrowserBot/BrowserContext.js
+++ b/examples/browser-only/src/BrowserBot/BrowserContext.js
@@ -1,28 +1,8 @@
-import BrowserEvent from './BrowserEvent';
+import { Context } from 'bottender';
 
-class BrowserContext {
-  constructor({ client, rawEvent, session }) {
-    this._client = client;
-    this._event = new BrowserEvent(rawEvent);
-    this._session = session;
-  }
-
-  sendText = text => {
+class BrowserContext extends Context {
+  sendText(text) {
     this._client.sendText(text);
-  };
-
-  sendTextWithDelay = (delay, text) => {
-    setTimeout(() => {
-      this.sendText(text);
-    }, delay);
-  };
-
-  get event() {
-    return this._event;
-  }
-
-  get session() {
-    return this._session;
   }
 }
 


### PR DESCRIPTION
`BrowserContext` must extends `Context` in Bottender v1, fix #588.