### PR TITLE
fix(session): should never expire by default

### DIFF
--- a/packages/bottender/src/cache/MemoryCacheStore.ts
+++ b/packages/bottender/src/cache/MemoryCacheStore.ts
@@ -28,7 +28,11 @@ export default class MemoryCacheStore implements CacheStore {
     // cloneDeep: To make sure save as writable object
     const val = value && typeof value === 'object' ? cloneDeep(value) : value;
 
-    this._lru.set(key, val, minutes * 60 * 1000);
+    if (minutes) {
+      this._lru.set(key, val, minutes * 60 * 1000);
+    } else {
+      this._lru.set(key, val);
+    }
   }
 
   async forget(key: string): Promise<void> {

--- a/packages/bottender/src/cache/RedisCacheStore.ts
+++ b/packages/bottender/src/cache/RedisCacheStore.ts
@@ -50,11 +50,15 @@ export default class RedisCacheStore implements CacheStore {
   }
 
   async put(key: string, value: CacheValue, minutes: number): Promise<void> {
-    await this._redis.setex(
-      `${this._prefix}${key}`,
-      minutes * 60,
-      this._serialize(value)
-    );
+    if (minutes) {
+      await this._redis.setex(
+        `${this._prefix}${key}`,
+        minutes * 60,
+        this._serialize(value)
+      );
+    } else {
+      await this._redis.set(`${this._prefix}${key}`, this._serialize(value));
+    }
   }
 
   async forget(key: string): Promise<void> {

--- a/packages/bottender/src/cache/__tests__/MemoryCacheStore.spec.ts
+++ b/packages/bottender/src/cache/__tests__/MemoryCacheStore.spec.ts
@@ -5,6 +5,7 @@ describe('#get', () => {
     const store = new MemoryCacheStore(5);
 
     await store.put('x', 'abc', 5);
+
     expect(await store.get('x')).toBe('abc');
   });
 
@@ -62,6 +63,22 @@ describe('#put', () => {
     Date.now = jest.fn(() => now + 6 * 60 * 1000);
 
     expect(await store.get('x')).toBeNull();
+    Date.now = _now;
+  });
+
+  it('should store cache item until it has been removed by LRU', async () => {
+    const _now = Date.now;
+    Date.now = jest.fn(() => 1234567891011);
+
+    const store = new MemoryCacheStore(5);
+
+    await store.put('x', 1, 0);
+    expect(await store.get('x')).toBe(1);
+
+    const now = Date.now();
+    Date.now = jest.fn(() => now + 6 * 60 * 1000);
+
+    expect(await store.get('x')).toBe(1);
     Date.now = _now;
   });
 

--- a/packages/bottender/src/cache/__tests__/RedisCacheStore.spec.ts
+++ b/packages/bottender/src/cache/__tests__/RedisCacheStore.spec.ts
@@ -114,6 +114,15 @@ describe('#put', () => {
     expect(redis.setex).toBeCalledWith('123', 300, '"xyz"');
   });
 
+  it('should store cache item', async () => {
+    const store = new RedisCacheStore();
+    const redis = store.getRedis();
+
+    await store.put('123', 'xyz', 0);
+
+    expect(redis.set).toBeCalledWith('123', '"xyz"');
+  });
+
   it('can store mixed data types', async () => {
     const store = new RedisCacheStore();
     const redis = store.getRedis();

--- a/packages/bottender/src/session/CacheBasedSessionStore.ts
+++ b/packages/bottender/src/session/CacheBasedSessionStore.ts
@@ -3,17 +3,15 @@ import CacheStore from '../cache/CacheStore';
 import Session from './Session';
 import SessionStore from './SessionStore';
 
-const MINUTES_IN_ONE_YEAR = 365 * 24 * 60;
-
 export default class CacheBasedSessionStore implements SessionStore {
   _cache: CacheStore;
 
   // The number of minutes to store the data in the session.
   _expiresIn: number;
 
-  constructor(cache: CacheStore, expiresIn: number) {
+  constructor(cache: CacheStore, expiresIn?: number) {
     this._cache = cache;
-    this._expiresIn = expiresIn || MINUTES_IN_ONE_YEAR;
+    this._expiresIn = expiresIn || 0;
   }
 
   async init(): Promise<CacheBasedSessionStore> {

--- a/packages/bottender/src/session/FileSessionStore.ts
+++ b/packages/bottender/src/session/FileSessionStore.ts
@@ -7,8 +7,6 @@ import subMinutes from 'date-fns/subMinutes';
 import Session from './Session';
 import SessionStore from './SessionStore';
 
-const MINUTES_IN_ONE_YEAR = 365 * 24 * 60;
-
 type FileOption =
   | string
   | {
@@ -32,7 +30,7 @@ export default class FileSessionStore implements SessionStore {
   _expiresIn: number;
 
   constructor(arg: FileOption, expiresIn?: number) {
-    this._expiresIn = expiresIn || MINUTES_IN_ONE_YEAR;
+    this._expiresIn = expiresIn || 0;
 
     const dirname = getDirname(arg) || '.sessions';
 
@@ -116,6 +114,10 @@ export default class FileSessionStore implements SessionStore {
   }
 
   _expired(sess: Session): boolean {
+    if (!this._expiresIn) {
+      return false;
+    }
+
     return (
       sess.lastActivity !== undefined &&
       isBefore(sess.lastActivity, subMinutes(Date.now(), this._expiresIn))

--- a/packages/bottender/src/session/MemorySessionStore.ts
+++ b/packages/bottender/src/session/MemorySessionStore.ts
@@ -3,8 +3,6 @@ import MemoryCacheStore from '../cache/MemoryCacheStore';
 import CacheBasedSessionStore from './CacheBasedSessionStore';
 import SessionStore from './SessionStore';
 
-const MINUTES_IN_ONE_YEAR = 365 * 24 * 60;
-
 type MemoryOption =
   | number
   | {
@@ -31,6 +29,6 @@ export default class MemorySessionStore extends CacheBasedSessionStore
 
     const cache = new MemoryCacheStore(maxSize);
 
-    super(cache, expiresIn || MINUTES_IN_ONE_YEAR);
+    super(cache, expiresIn);
   }
 }

--- a/packages/bottender/src/session/MongoSessionStore.ts
+++ b/packages/bottender/src/session/MongoSessionStore.ts
@@ -5,8 +5,6 @@ import { Collection, Db, MongoClient } from 'mongodb';
 import Session from './Session';
 import SessionStore from './SessionStore';
 
-const MINUTES_IN_ONE_YEAR = 365 * 24 * 60;
-
 type MongoOption =
   | string
   | {
@@ -32,7 +30,7 @@ export default class MongoSessionStore implements SessionStore {
       this._url = options.url;
       this._collectionName = options.collectionName || 'sessions';
     }
-    this._expiresIn = expiresIn || MINUTES_IN_ONE_YEAR;
+    this._expiresIn = expiresIn || 0;
   }
 
   async init(): Promise<MongoSessionStore> {
@@ -89,6 +87,10 @@ export default class MongoSessionStore implements SessionStore {
   }
 
   _expired(sess: Session): boolean {
+    if (!this._expiresIn) {
+      return false;
+    }
+
     return (
       sess.lastActivity !== undefined &&
       isBefore(sess.lastActivity, subMinutes(Date.now(), this._expiresIn))

--- a/packages/bottender/src/session/RedisSessionStore.ts
+++ b/packages/bottender/src/session/RedisSessionStore.ts
@@ -3,8 +3,6 @@ import RedisCacheStore from '../cache/RedisCacheStore';
 import CacheBasedSessionStore from './CacheBasedSessionStore';
 import SessionStore from './SessionStore';
 
-const MINUTES_IN_ONE_YEAR = 365 * 24 * 60;
-
 type RedisOption =
   | number
   | string
@@ -20,6 +18,6 @@ export default class RedisSessionStore extends CacheBasedSessionStore
   implements SessionStore {
   constructor(arg: RedisOption, expiresIn?: number) {
     const cache = new RedisCacheStore(arg);
-    super(cache, expiresIn || MINUTES_IN_ONE_YEAR);
+    super(cache, expiresIn);
   }
 }


### PR DESCRIPTION
In our docs, we say session will never expire by default, so this is a quick fix. In other hand, one year is not a good default value from our perspective.