### PR TITLE
docs: fix typo and errors in Messenger Guides

### DIFF
--- a/docs/channel-messenger-handling-events.md
+++ b/docs/channel-messenger-handling-events.md
@@ -3,10 +3,10 @@ id: channel-messenger-handling-events
 title: Handling Messenger Events
 ---
 
-For a Messenger bot, the two most frequent LINE events are `Text Event` and `Payload Event.`
+For a Messenger bot, the two most frequent Messenger events are `Text Event` and `Payload Event.`
 
 - `Text Event` is triggered when a user inputs text.
-- `Payload Event` can be triggered by postback buttons on template, imagemap, flex messages and rich menus, or quick replies.
+- `Payload Event` can be triggered by postback buttons on all kinds of templates, buttons, persistent menu, or quick replies.
 
 Apart from the above events, Messenger also supports advanced events for better user experience. For example, [`Media Related Events`](#media-related-events) offer a bunch of events when users send a piece of rich media to a bot, for instance, image, video, audio, and file. [Delivery/Read Event](#deliveryread-events) is handy while calculating how many users received a broadcast message. A humor response of [Sticker Event](#sticker-events), makes your bot more human-like.
 
@@ -85,9 +85,9 @@ async function App(context) {
 
 ### Media Related Events
 
-In our current experience, image and location is comparatively accessible. For example, an `Image Event` could be a starting point for image-based search engine to find relevant products. And `Location Event` is often used under the context that when your bot tries to recommendation your user nearby shops or branches.
+In our current experience, image and location are comparatively accessible. For example, an `Image Event` could be a starting point for a image-based search engine to find relevant products. And `Location Event` is often used under the context that when your bot tries to recommendation your user nearby shops or branches.
 
-In the following example, you can see a bunch of `Media Related Events,` from image, audio, video, file, and location.
+In the following example, you can see a bunch of `Media Related Events` from image, audio, video, file, and location.
 
 ```js
 async function HandleImage(context) {
@@ -161,7 +161,7 @@ async function App(context) {
 
 ### Sticker Events
 
-A proper response of `Sticker Event` would make your bot more human-like. For example, you can define a set of stickers that your bots understand as a shortcut (or sercret code). It offers an alternative way for your user to interact with your bot.
+A proper response of `Sticker Event` would make your bot more human-like. For example, you can define a set of stickers that your bots understand as a shortcut (or secret code). It offers an alternative way for your user to interact with your bot.
 
 In the following example, you can see an example of the famous `Like Sticker` (a growing big thumb up).
 

--- a/docs/channel-messenger-profile.md
+++ b/docs/channel-messenger-profile.md
@@ -42,7 +42,7 @@ After setting environment variables correctly (if not, please check [this](chann
 npx bottender messenger profile set
 ```
 
-> **Note:** Calls to the Messenger Profile API are limited to **10 API calls per 10 minute** interval. This rate limit is enforced per Page. You can retry it a few minutes later if rate limit exceeded.
+> **Note:** Calls to the Messenger Profile API are limited to **10 API calls per 10 minute** interval. This rate limit is enforced per Page. You could retry it a few minutes later if the rate limit exceeded.
 
 To view all set messenger profile, you may use the `messenger profile get` command:
 
@@ -219,7 +219,7 @@ module.exports = {
 
 `question` will be posted on the thread as the user asking the question and `payload` will be returned as a postback webhook event.
 
-> **Note:** Some of the profile elements like Ice Breakers and Get Started button are incompatible with each other. So when both are set one will take precedence over the other. Here is the priority from highest to lowest:
+> **Note:** Some of the profile elements like Ice Breakers and Get Started button are incompatible with each other. So when both are set, one will take precedence over the other. Here is the priority from highest to lowest:
 >
 > - API Ice Breakers
 > - Get Started button

--- a/docs/channel-messenger-sending-messages.md
+++ b/docs/channel-messenger-sending-messages.md
@@ -9,12 +9,12 @@ Although the document is about "sending messages," in most of the cases, Messeng
 
 > **Note:**
 >
-> - If you want to know better about when your bots can send message proactively, please refer to Messenger's guide link about [Messenger Platform Policy Overview](https://developers.facebook.com/docs/messenger-platform/policy/policy-overview#standard_messaging)
-> - We have a separate document to introduce user event handling, please refer to [Handling Messenger Events](./channel-messenger-handling-events.md)
+> - If you want to know better about when your bots can send message proactively, please refer to Messenger's guide link about [Messenger Platform Policy Overview](https://developers.facebook.com/docs/messenger-platform/policy/policy-overview#standard_messaging).
+> - We have a separate document to introduce user event handling, please refer to [Handling Messenger Events](./channel-messenger-handling-events.md).
 
 If you are not familiar with Messenger messages, we would like to recommend a short happy path.
 
-To begin with, please try the basis of communication, [`Text Messages`](#sending-text-messages). Secondly, try [`Generic Template Messages`](#sending-template-messages) to help you display a collection of items (e.g., recommended restaurants, songs, or books). Finally, - [`Quick Replies`](#sending-with-quick-reply), which continuously guide your users for the next possible actions.
+To begin with, please try the basis of communication, [`Text Messages`](#sending-text-messages). Secondly, try [`Generic Template Messages`](#sending-template-messages) to help you display a collection of items (e.g., recommended restaurants, songs, or books). Finally, - [`Quick Replies`](#sending-with-quick-reply), which continuously guides your users for the next possible actions.
 
 If you have experienced with Messenger messages, don't miss [`Rich Media Messages`](#sending-rich-media-messages) to show the personality of your bots. [`Rich Media Messages`](#sending-rich-media-messages) and [`Media Template Messages`](#media-template) are necessary if you are building a media-driven, storytelling bot. Take a look at [`Persona`](#sending-with-persona), if you offer bot auto-reply and human agent customer support at the same time. Finally, if you are making a chatbot for campaign purposes, please dive into [`Rate Limits`](#rate-limits) to ensure your bot is ready for high traffic.
 
@@ -59,7 +59,7 @@ If you want to benefit from Facebook's cache, i.e., a much pleasant loading spee
 
 Firstly, you need to get a page-scoped `Attachment Id` by [Attachment Upload API](https://developers.facebook.com/docs/messenger-platform/send-messages/saving-assets#attachment_upload_api).
 
-Once you have get your `Attachment Id`, you can send rich media messages with the following code.
+Once you get your `Attachment Id`, you can send rich media messages with the following code.
 
 ```js
 await context.sendImage({ attachmentId: '<ATTACHMENT_ID>' });
@@ -319,7 +319,7 @@ The `User Email Quick Reply` can be treated as an agree button to collect the us
 Messenger automatically pre-fill the displayed quick reply with the Email from the user's profile information. Since many CRM (Customer Relationship Management) use the Email as a unique id, it is handy for future user mapping.
 
 > **Note:**
-> If the user's profile does not have a Email, the quick reply doesn't show up. Also, the bot only receives the Email until the user clicks the quick reply.
+> If the user's profile does not have an Email, the quick reply doesn't show up. Also, the bot only receives the Email until the user clicks the quick reply.
 
 ```js
 await context.sendText('Hi!', {
@@ -343,7 +343,7 @@ await context.sendText('Hi!', {
 
 ## Rate Limits
 
-If you are making a bot with a sudden high traffic, e.g., a campaign bot for Black Friday, you should deal with `Rate Limits` before you receive [error code 613](https://developers.facebook.com/docs/messenger-platform/reference/send-api/error-codes).
+If you are making a bot with sudden high traffic, e.g., a campaign bot for Black Friday, you should deal with `Rate Limits` before you receive [error code 613](https://developers.facebook.com/docs/messenger-platform/reference/send-api/error-codes).
 
 Page Rate limits are in place to prevent malicious behavior and poor user experiences. For Pages with large audiences, Messenger recommends a send rate of 250 requests per second.
 

--- a/docs/channel-messenger-setup.md
+++ b/docs/channel-messenger-setup.md
@@ -19,7 +19,7 @@ Make sure that you checked the `messenger` option:
 
 ![](https://user-images.githubusercontent.com/3382565/67851223-f2b7f200-fb44-11e9-960a-4f58d68ab37d.png)
 
-After finishing `Create Bottender App` process, `bottender.config.js`, a config file, will be generated automatically for furthur channel settings.
+After finishing `Create Bottender App` process, `bottender.config.js`, a config file, will be generated automatically for further channel settings.
 
 ### Enable Messenger Channel for Existing Apps
 
@@ -56,7 +56,7 @@ To make a Messenger bot work, you have to setup the following values:
 
 ### Messenger Page Id, Messenger Access Token, Messenger App Id, Messenger App Secret, and Messenger Verify Token
 
-These fields could be found on your Facebook App page, which you can accessed from your [Facebook App Dashboard](https://developers.facebook.com/apps). Then, you need to fill in corresponding fields in `.env` for loading those values correctly into `bottender.config.js`:
+These fields could be found on your Facebook App page, which you can access from your [Facebook App Dashboard](https://developers.facebook.com/apps). Then, you need to fill in corresponding fields in `.env` for loading those values correctly into `bottender.config.js`:
 
 ```
 MESSENGER_PAGE_ID=
@@ -72,7 +72,7 @@ MESSENGER_VERIFY_TOKEN=
 
 ### Webhook
 
-After finishing above settings, you can start your server with Messenger webhook event listening using following commands:
+After finishing the above settings, you can start your server with Messenger webhook event listening using the following commands:
 
 ```sh
 # in production mode
@@ -92,4 +92,4 @@ Now you are ready to interact with your bot on Messenger :)
 
 > **Note:**
 >
-> - Before you release your bot to the public, you have to submit your App to Facebook to get relevant permissions, e.g. `pages_message`. See Facebook's official document, [Submitting Your Messenger App](https://developers.facebook.com/docs/messenger-platform/app-review/), for more information.
+> - Before you release your bot to the public, you have to submit your App to Facebook to get relevant permissions, e.g., `pages_message`. See Facebook's official document, [Submitting Your Messenger App](https://developers.facebook.com/docs/messenger-platform/app-review/), for more information.


### PR DESCRIPTION
Fix typos and grammar errors in Messenger Guides sections.