### PR TITLE
docs: fix typo and errors in LINE Guides

### DIFF
--- a/docs/channel-line-errors.md
+++ b/docs/channel-line-errors.md
@@ -5,13 +5,13 @@ title: Error Handling in LINE
 
 ## Customizing the Error Message in Different Environments Using Reply/Push
 
-In development and production, you may choose different approaches for sending error messages, since LINE `Reply API` and `Push API` have fundamental differences.
+In development and production environments, you may choose different approaches for sending error messages, since LINE `Reply API` and `Push API` have fundamental differences.
 
-- `Push API` allows developers to send messages directly to users anytime. However, it is only free when your bot is in development. In production, you may refer to [LINE Official Account Subscription Plans](https://www.linebiz.com/id-en/service/line-account-connect/) to check out the message fee.
+- `Push API` allows developers to send messages directly to users anytime. However, it is only free when your bot is in the development environment. In the production environment, you may refer to [LINE Official Account Subscription Plans](https://www.linebiz.com/id-en/service/line-account-connect/) to check out the message fee.
 
 - `Reply API` is free. But bots can only reply with a message to a user who interacts with your LINE official account.
 
-When it comes to error handling in the development, you can benefit from the free `Push API` to send error messages. But in the production, if your bot is still available to reply, you can choose to respond to your user an error message.
+When it comes to error handling in the development environment, you can benefit from the free `Push API` to send error messages. But in the production environment, if your bot is still available to reply, you can choose to respond to your user an error message.
 
 ```js
 // _error.js

--- a/docs/channel-line-handling-events.md
+++ b/docs/channel-line-handling-events.md
@@ -117,7 +117,7 @@ async function App(context) {
 
 ### Group/Room Events
 
-A bot inside group/room makes various kinds of group vote possible, e.g., the restaurant for lunch, the destination for the company trip, or gifts for lucky draw. In the following example, you can see how to handle `Join Event` and `Leave Event.`
+A bot inside group/room makes various kinds of group vote possible, e.g., the restaurant for lunch, the destination for the company trip, or gifts for a lucky draw. In the following example, you can see how to handle `Join Event` and `Leave Event.`
 
 > **Note:**
 > We are preparing an advanced `Group/Room Events` tutorial to illustrate more practical group bot usages. If you are interested in it, please tell us on [Bottender Discord/#LINE](https://discord.gg/BsS9Fwe) to upvote :D

--- a/docs/channel-line-sending-messages.md
+++ b/docs/channel-line-sending-messages.md
@@ -236,7 +236,7 @@ await context.sendImagemap(altText, imagemap);
 
 `Template message` is an interactive gallery composed of image, video, title, subtitle, and buttons.
 
-`Template message` is the key to offer rich media interaction. It usually used in the scenario of display multiple choices, and next actions to the user, e.g., applying coupons, booking a room, making a reservation.
+`Template message` is the key to offer rich media interaction. It is usually used in the scenario of display multiple choices and next actions to the user, e.g., applying coupons, booking a room, making a reservation.
 
 > **Note:**
 > Compared with `Template Message,` we highly depend on [`Flex Message`](./channel-line-flex.md) once it is available. There are two main reasons:

--- a/docs/channel-line-setup.md
+++ b/docs/channel-line-setup.md
@@ -50,7 +50,7 @@ To make a LINE bot work, you have to setup three values:
 
 ### LINE Access Token & Channel Secret
 
-`bottender.config.js` looks up `.env` for LINE access token and LINE channel secrect. Those two values have to be copied from LINE@ account settings and pasted to the the following fields in `.env`.
+`bottender.config.js` looks up `.env` for LINE access token and LINE channel secret. Those two values have to be copied from LINE@ account settings and pasted to the following fields in `.env`.
 
 ```
 LINE_ACCESS_TOKEN=
@@ -61,11 +61,11 @@ LINE_CHANNEL_SECRET=
 >
 > - It is recommended to develop your LINE Bot with your developer LINE@ account, further information could be found in LINE's official article, [Getting Started](https://developers.line.biz/en/docs/messaging-api/getting-started/).
 > - Your LINE@ account can be accessed from your [provider list](https://developers.line.biz/console/).
-> - To get your LINE access token and LINE channel secrect, you may refer to LINE's official article, [Building a Bot](https://developers.line.biz/en/docs/messaging-api/building-bot/).
+> - To get your LINE access token and LINE channel secret, you may refer to LINE's official article, [Building a Bot](https://developers.line.biz/en/docs/messaging-api/building-bot/).
 
 ### Webhook
 
-After finishing above settings, you can start your server with LINE webhook event listening using following commands:
+After finishing the above settings, you can start your server with LINE webhook event listening using the following commands:
 
 ```sh
 # in production mode
@@ -83,7 +83,7 @@ line webhook url: https://42bbf602.ngrok.io/webhooks/line
 server is running on 5000 port...
 ```
 
-Then, you have to manually copy your webhook url to LINE@ account's setting page. Finally, you are ready to interact with your bot on LINE :)
+Then, you have to manually copy your webhook url to LINE@ account's settings page. Finally, you are ready to interact with your bot on LINE :)
 
 > **Note:**
 >

--- a/docs/channel-messenger-handling-events.md
+++ b/docs/channel-messenger-handling-events.md
@@ -85,7 +85,7 @@ async function App(context) {
 
 ### Media Related Events
 
-In our current experience, image and location are comparatively accessible. For example, an `Image Event` could be a starting point for a image-based search engine to find relevant products. And `Location Event` is often used under the context that when your bot tries to recommendation your user nearby shops or branches.
+In our current experience, image and location are comparatively accessible. For example, an `Image Event` could be a starting point for an image-based search engine to find relevant products. And `Location Event` is often used under the context that when your bot tries to recommendation your user nearby shops or branches.
 
 In the following example, you can see a bunch of `Media Related Events` from image, audio, video, file, and location.
 


### PR DESCRIPTION
Fix typos and grammar errors in LINE Guides sections.

