### PR TITLE
feat: improve error messages for bots configuration

### DIFF
--- a/packages/bottender/src/line/LineBot.ts
+++ b/packages/bottender/src/line/LineBot.ts
@@ -24,7 +24,7 @@ export default class LineBot extends Bot<
   }: {
     accessToken: string;
     channelSecret: string;
-    sessionStore: SessionStore;
+    sessionStore?: SessionStore;
     sync?: boolean;
     mapDestinationToAccessToken?: (destination: string) => Promise<string>;
     shouldBatch?: boolean;

--- a/packages/bottender/src/line/LineConnector.ts
+++ b/packages/bottender/src/line/LineConnector.ts
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import crypto from 'crypto';
 
+import invariant from 'invariant';
 import warning from 'warning';
 import { LineClient } from 'messaging-api-line';
 
@@ -66,6 +67,15 @@ export default class LineConnector
       this._channelSecret = '';
     } else {
       const { accessToken, channelSecret, origin } = options;
+
+      invariant(
+        options.accessToken,
+        'LINE access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
+      invariant(
+        options.channelSecret,
+        'LINE channel secret is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
 
       this._client = LineClient.connect({
         accessToken,

--- a/packages/bottender/src/messenger/MessengerBot.ts
+++ b/packages/bottender/src/messenger/MessengerBot.ts
@@ -27,7 +27,7 @@ export default class MessengerBot extends Bot<
     accessToken: string;
     appId: string;
     appSecret: string;
-    sessionStore: SessionStore;
+    sessionStore?: SessionStore;
     sync?: boolean;
     mapPageToAccessToken?: (pageId: string) => Promise<string>;
     verifyToken?: string;

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'events';
 import crypto from 'crypto';
 import { URL } from 'url';
 
+import invariant from 'invariant';
 import isAfter from 'date-fns/isAfter';
 import isValid from 'date-fns/isValid';
 import shortid from 'shortid';
@@ -132,6 +133,16 @@ export default class MessengerConnector
       this._client = options.client;
     } else {
       const { accessToken, origin, skipAppSecretProof } = options;
+
+      invariant(
+        accessToken || mapPageToAccessToken,
+        'Messenger access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
+      invariant(
+        appSecret,
+        'Messenger app secret is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
+
       this._client = MessengerClient.connect({
         accessToken: accessToken || '',
         appSecret,

--- a/packages/bottender/src/messenger/__tests__/MessengerBot.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/MessengerBot.spec.ts
@@ -5,9 +5,13 @@ beforeEach(() => {
   console.error = jest.fn();
 });
 
+const ACCESS_TOKEN = 'FAKE_TOKEN';
+const APP_SECRET = 'FAKE_SECRET';
+
 it('should construct bot with MessengerConnector', () => {
   const bot = new MessengerBot({
-    accessToken: 'FAKE_TOKEN',
+    accessToken: ACCESS_TOKEN,
+    appSecret: APP_SECRET,
   });
   expect(bot).toBeDefined();
   expect(bot.onEvent).toBeDefined();

--- a/packages/bottender/src/slack/SlackBot.ts
+++ b/packages/bottender/src/slack/SlackBot.ts
@@ -23,7 +23,7 @@ export default class SlackBot extends Bot<
     skipLegacyProfile,
   }: {
     accessToken: string;
-    sessionStore: SessionStore;
+    sessionStore?: SessionStore;
     sync?: boolean;
     verificationToken?: string;
     origin?: string;

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import crypto from 'crypto';
 
+import invariant from 'invariant';
 import pProps from 'p-props';
 import warning from 'warning';
 import { SlackOAuthClient } from 'messaging-api-slack';
@@ -68,6 +69,12 @@ export default class SlackConnector
       this._client = options.client;
     } else {
       const { accessToken, origin } = options;
+
+      invariant(
+        accessToken,
+        'Viber access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
+
       this._client = SlackOAuthClient.connect({
         accessToken,
         origin,

--- a/packages/bottender/src/telegram/TelegramBot.ts
+++ b/packages/bottender/src/telegram/TelegramBot.ts
@@ -29,7 +29,7 @@ export default class TelegramBot extends Bot<
     origin,
   }: {
     accessToken: string;
-    sessionStore: SessionStore;
+    sessionStore?: SessionStore;
     sync?: boolean;
     origin?: string;
   }) {

--- a/packages/bottender/src/telegram/TelegramConnector.ts
+++ b/packages/bottender/src/telegram/TelegramConnector.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 
+import invariant from 'invariant';
 import { TelegramClient } from 'messaging-api-telegram';
 
 import Session from '../session/Session';
@@ -38,6 +39,11 @@ export default class TelegramConnector
       this._client = options.client;
     } else {
       const { accessToken, origin } = options;
+
+      invariant(
+        options.accessToken,
+        'Telegram access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
 
       this._client = TelegramClient.connect({
         accessToken,

--- a/packages/bottender/src/viber/ViberConnector.ts
+++ b/packages/bottender/src/viber/ViberConnector.ts
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import crypto from 'crypto';
 
+import invariant from 'invariant';
 import { ViberClient, ViberTypes } from 'messaging-api-viber';
 import { addedDiff } from 'deep-object-diff';
 
@@ -43,6 +44,11 @@ export default class ViberConnector
       this._client = options.client;
     } else {
       const { accessToken, sender, origin } = options;
+
+      invariant(
+        options.accessToken,
+        'Viber access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+      );
 
       this._client = ViberClient.connect(
         {


### PR DESCRIPTION
Improved error message mentioned in #586:

TypeError [ERR_INVALID_ARG_TYPE]: The "key" argument must be one of type Buffer, TypedArray, DataView, string, or KeyObject. Received type undefined
