### PR TITLE
fix: improve error message when there are errors in bottender.config.js

### DIFF
--- a/packages/bottender/src/cli/index.ts
+++ b/packages/bottender/src/cli/index.ts
@@ -89,7 +89,8 @@ const main = async (argvFrom2: string[]) => {
   } catch (err) {
     console.error(
       error(
-        `An unexpected error occurred in provider ${subcommand}: ${err.stack}`
+        `An unexpected error occurred in provider ${subcommand}: ${err.message}
+${err.stack}`
       )
     );
   }
@@ -97,7 +98,8 @@ const main = async (argvFrom2: string[]) => {
 
 const handleUnexpected = (err: Error): void => {
   console.error(
-    error(`An unexpected error occurred!\n  ${err.stack} ${err.stack}`)
+    error(`An unexpected error occurred: ${err.message}
+${err.stack}`)
   );
   process.exit(1);
 };
@@ -107,7 +109,7 @@ const handleRejection = (reason: Error | any): void => {
     if (reason instanceof Error) {
       handleUnexpected(reason);
     } else {
-      console.error(error(`An unexpected rejection occurred\n  ${reason}`));
+      console.error(error(`An unexpected rejection occurred: ${reason}`));
     }
   } else {
     console.error(error('An unexpected empty rejection occurred'));

--- a/packages/bottender/src/shared/getBottenderConfig.ts
+++ b/packages/bottender/src/shared/getBottenderConfig.ts
@@ -14,7 +14,12 @@ const getBottenderConfig = (): BottenderConfig | never => {
     // eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-var-requires
     return require(path.resolve('bottender.config.js'));
   } catch (err) {
-    return {};
+    // if config is not found, return empty config
+    if (err.code && err.code === 'MODULE_NOT_FOUND') {
+      return {};
+    }
+
+    throw err;
   }
 };
 


### PR DESCRIPTION
When any syntax errors happen in `bottender.config.js`, it should show those errors instead of failing silently.