### PR TITLE
fix(examples): use latest bottender instead of next bottender

### DIFF
--- a/examples/browser-only/package.json
+++ b/examples/browser-only/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@chentsulin/react-botui": "^0.2.1",
-    "bottender": "next",
+    "bottender": "latest",
     "botui": "^0.3.9",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/examples/custom-server-express/package.json
+++ b/examples/custom-server-express/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "bottender": "next",
+    "bottender": "latest",
     "cross-env": "^6.0.3",
     "express": "^4.17.1"
   },

--- a/examples/custom-server-koa/package.json
+++ b/examples/custom-server-koa/package.json
@@ -4,7 +4,7 @@
     "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "bottender": "next",
+    "bottender": "latest",
     "cross-env": "^6.0.3",
     "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",

--- a/examples/custom-server-restify/package.json
+++ b/examples/custom-server-restify/package.json
@@ -4,7 +4,7 @@
     "start": "cross-env NODE_ENV=production node server.js"
   },
   "dependencies": {
-    "bottender": "next",
+    "bottender": "latest",
     "cross-env": "^6.0.3",
     "restify": "^8.5.0"
   },

--- a/examples/echo-bot/package.json
+++ b/examples/echo-bot/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/line-hello-world/package.json
+++ b/examples/line-hello-world/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/line-rich-menu-submenu/package.json
+++ b/examples/line-rich-menu-submenu/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/line-rich-menu/package.json
+++ b/examples/line-rich-menu/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-batch-multi-pages/package.json
+++ b/examples/messenger-batch-multi-pages/package.json
@@ -4,7 +4,7 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next",
+    "bottender": "latest",
     "messenger-batch": "^0.3.1"
   }
 }

--- a/examples/messenger-batch/package.json
+++ b/examples/messenger-batch/package.json
@@ -4,7 +4,7 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next",
+    "bottender": "latest",
     "messenger-batch": "^0.3.1"
   }
 }

--- a/examples/messenger-built-in-nlp/package.json
+++ b/examples/messenger-built-in-nlp/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-handover/package.json
+++ b/examples/messenger-handover/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-hello-world/package.json
+++ b/examples/messenger-hello-world/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-multi-pages/package.json
+++ b/examples/messenger-multi-pages/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-persistent-menu/package.json
+++ b/examples/messenger-persistent-menu/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-persona/package.json
+++ b/examples/messenger-persona/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/messenger-typing/package.json
+++ b/examples/messenger-typing/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/multiple-channels/package.json
+++ b/examples/multiple-channels/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/session-file/package.json
+++ b/examples/session-file/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/session-memory/package.json
+++ b/examples/session-memory/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/session-mongo/package.json
+++ b/examples/session-mongo/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/session-redis/package.json
+++ b/examples/session-redis/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/slack-hello-world/package.json
+++ b/examples/slack-hello-world/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/slack-interactive-message/package.json
+++ b/examples/slack-interactive-message/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/telegram-hello-world/package.json
+++ b/examples/telegram-hello-world/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/todos/package.json
+++ b/examples/todos/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/viber-hello-world/package.json
+++ b/examples/viber-hello-world/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/with-dialogflow/package.json
+++ b/examples/with-dialogflow/package.json
@@ -4,7 +4,7 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next",
+    "bottender": "latest",
     "dialogflow": "^0.14.1"
   }
 }

--- a/examples/with-luis.ai/package.json
+++ b/examples/with-luis.ai/package.json
@@ -4,7 +4,7 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next",
-    "axios": "^0.19.0"
+    "axios": "^0.19.0",
+    "bottender": "latest"
   }
 }

--- a/examples/with-qna-maker/package.json
+++ b/examples/with-qna-maker/package.json
@@ -5,6 +5,6 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/with-rasa/package.json
+++ b/examples/with-rasa/package.json
@@ -5,6 +5,6 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
-    "bottender": "next"
+    "bottender": "latest"
   }
 }

--- a/examples/with-state/package.json
+++ b/examples/with-state/package.json
@@ -4,6 +4,6 @@
     "start": "bottender start"
   },
   "dependencies": {
-    "bottender": "next"
+    "bottender": "latest"
   }
 }


### PR DESCRIPTION
We should prevent our users from installing beta bottender when trying examples.