### PR TITLE
docs(examples/*/readme.md): unify readme format

### DIFF
--- a/examples/browser-only/README.md
+++ b/examples/browser-only/README.md
@@ -13,7 +13,7 @@ npm run start
 
 ![](https://user-images.githubusercontent.com/3382565/71249572-75487b00-2358-11ea-90a3-f4fdbd6dd4bb.gif)
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on your browser.
 It shows how to build a frontend bot (no server) with React.

--- a/examples/echo-bot/README.md
+++ b/examples/echo-bot/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This is a simple console bot which will echo what you said and shows how to
 distinguish what kind of message the bot has received. The easiest way is to use

--- a/examples/line-hello-world/README.md
+++ b/examples/line-hello-world/README.md
@@ -1,4 +1,4 @@
-# LINE hello world
+# LINE Hello World
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken` and `channelSecret` into `index.js`.
+You must put `accessToken` and `channelSecret` into `bottender.config.js`.
+
+If you are not familiar with LINE Bot, you may refer to Bottender's doc, [Setup LINE](https://bottender.js.org/docs/channel-line-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,18 +27,18 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/line` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/line` from command line.
 
-## Set webhook
+## Set Webhook
 
-To set the webhook, go to [LINE developers console](https://developers.line.me/console/) and use the webhook url you get from running `npm run dev` to edit webhook information for your channel.
+To set the webhook, go to [LINE developers console](https://developers.line.me/console/) and use the webhook URL you get from running `npm run dev` to edit webhook information for your channel.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [LINE](https://line.me/).
 For more information, check our [LINE guides](https://bottender.js.org/docs/channel-line-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)
 - [slack-hello-world](../slack-hello-world)

--- a/examples/line-rich-menu-submenu/README.md
+++ b/examples/line-rich-menu-submenu/README.md
@@ -1,4 +1,4 @@
-# LINE rich menu submenu
+# LINE Rich Menu Submenu
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken` and `channelSecret` into `index.js`.
+You must put `accessToken` and `channelSecret` into `bottender.config.js`.
+
+If you are not familiar with LINE Bot, you may refer to Bottender's doc, [Setup LINE](https://bottender.js.org/docs/channel-line-setup) to find detailed instructions.
 
 After that, you should follow this [document](https://bottender.js.org/docs/channel-line-rich-menu#set-up-submenu) to set up three rich menu objects. You can use the file `main_menu.jpg`, `submenu_A.jpg`, `submenu_B.jpg` as the rich menu images.
 
@@ -27,17 +29,17 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/line` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/line` from command line.
 
-## Set webhook
+## Set Webhook
 
-To set the webhook, go to [LINE developers console](https://developers.line.me/console/) and use the webhook url you get from running `npm run dev` to edit webhook information for your channel.
+To set the webhook, go to [LINE developers console](https://developers.line.me/console/) and use the webhook URL you get from running `npm run dev` to edit webhook information for your channel.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [LINE](https://line.me/) to demonstrate how to set up submenus under a main rich menu.
 
-## Related examples
+## Related Examples
 
 - [line-hello-world](../line-hello-world)
 - [line-rich-menu](../line-rich-menu)

--- a/examples/line-rich-menu/README.md
+++ b/examples/line-rich-menu/README.md
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken` and `channelSecret` into `index.js`.
+You must put `accessToken` and `channelSecret` into `bottender.config.js`.
+
+If you are not familiar with LINE Bot, you may refer to Bottender's doc, [Setup LINE](https://bottender.js.org/docs/channel-line-setup) to find detailed instructions.
 
 After that, you should follow this [document](https://bottender.js.org/docs/channel-line-rich-menu) to set up the rich menu on LINE. You can use the file `rich_menu.jpg` as the rich menu image.
 
@@ -27,15 +29,15 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/line` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/line` from command line.
 
-## Set webhook
+## Set Webhook
 
-To set the webhook, go to [LINE developers console](https://developers.line.me/console/) and use the webhook url you get from running `npm run dev` to edit webhook information for your channel.
+To set the webhook, go to [LINE developers console](https://developers.line.me/console/) and use the webhook URL you get from running `npm run dev` to edit webhook information for your channel.
 
-## Idea of this example
+## Idea of this Example
 
-This example is a simple bot running on [LINE](https://line.me/) to demonstrate how to use rich menu.
+This example is a simple bot running on [LINE](https://line.me/) to demonstrate how to use Rich menu.
 For more information, check our [LINE API Document](https://developers.line.biz/en/reference/messaging-api/#rich-menu).
 
 ## Related examples

--- a/examples/messenger-batch-multi-pages/README.md
+++ b/examples/messenger-batch-multi-pages/README.md
@@ -1,4 +1,4 @@
-# Messenger batch multi-pages example
+# Messenger Batch Multi-Pages Example
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,13 +27,13 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
 > Note: You must set `PAGE_ID` and `ACCESS_TOKEN` env variables pairs before running this command.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
@@ -39,12 +41,12 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/) to reply separately by different page.\
 For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-batch](../messenger-batch)
 - [messenger-multi-pages](../messenger-multi-pages)

--- a/examples/messenger-batch/README.md
+++ b/examples/messenger-batch/README.md
@@ -1,4 +1,4 @@
-# Messenger batch
+# Messenger Batch
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,11 +27,11 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
@@ -37,7 +39,7 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a bot which sents multiple requsets (up to 50) in batches using `batchConfig` in bottender.config.js:
 
@@ -66,7 +68,7 @@ module.exports = {
 
 [messenger batch](https://github.com/Yoctol/messenger-batch) implemented the approach described in [Making Batch Requests](https://developers.facebook.com/docs/graph-api/making-multiple-requests/).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)
 - [messenger-batch-multi-pages](../messenger-batch-multi-pages)

--- a/examples/messenger-built-in-nlp/README.md
+++ b/examples/messenger-built-in-nlp/README.md
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 Also, to enable built-in NLP, you should setup related settings following the official docs [Messenger Built-in NLP](https://developers.facebook.com/docs/messenger-platform/built-in-nlp/).
 
@@ -27,11 +29,11 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
@@ -39,11 +41,11 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/) with `buit-in NLP` enabled.
 For more information, check the official docs [Messenger Built-in NLP](https://developers.facebook.com/docs/messenger-platform/built-in-nlp/).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)

--- a/examples/messenger-handover/README.md
+++ b/examples/messenger-handover/README.md
@@ -1,6 +1,6 @@
 # Messenger Handover
 
-## Install
+## Install and Run
 
 Download this example or clone [bottender](https://github.com/Yoctol/bottender).
 
@@ -15,17 +15,13 @@ Install dependencies:
 npm install
 ```
 
-## Fill in Environment Variables
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
 
-First, you have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
-If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup) to find detailed instructions.
-
-To make this example works, you may also found that we enabled a few necessary `Messenger Subscriptions` in `bottender.js.config`, e.g., `message_echoes`, `standby`, and `messaging_handovers`.
+To make this example works, you may found that we enabled a few necessary `Messenger Subscriptions` in `bottender.config.js`, e.g., `message_echoes`, `standby`, and `messaging_handovers`.
 
 `Messenger Subscriptions` take effect when you run the below `Set Webhook` script.
-
-## Run
 
 After that, you can run the bot with this npm script:
 

--- a/examples/messenger-handover/README.md
+++ b/examples/messenger-handover/README.md
@@ -19,7 +19,7 @@ You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` 
 
 If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
-To make this example works, you may found that we enabled a few necessary `Messenger Subscriptions` in `bottender.config.js`, e.g., `message_echoes`, `standby`, and `messaging_handovers`.
+To make this example works, you may found that we enabled a few necessary `Page Subscriptions Fields` in `bottender.config.js`, e.g., `message_echoes`, `standby`, and `messaging_handovers`.
 
 `Messenger Subscriptions` take effect when you run the below `Set Webhook` script.
 

--- a/examples/messenger-hello-world/README.md
+++ b/examples/messenger-hello-world/README.md
@@ -1,4 +1,4 @@
-# Messenger hello world
+# Messenger Hello world
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,11 +27,11 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
@@ -37,12 +39,12 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/).
 For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
-## Related examples
+## Related Examples
 
 - [line-hello-world](../line-hello-world)
 - [slack-hello-world](../slack-hello-world)

--- a/examples/messenger-persistent-menu/README.md
+++ b/examples/messenger-persistent-menu/README.md
@@ -1,4 +1,4 @@
-# Messenger persistent menu
+# Messenger Persistent Menu
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 To set messenger profile, run following command with `bottender`:
 
@@ -31,9 +33,9 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
-## Set webhook
+## Set Webhook
 
 While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
 
@@ -43,11 +45,11 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 It shows how to set a [persistent menu](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/persistent-menu/) on [Messenger](https://www.messenger.com/).
 For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)

--- a/examples/messenger-persona/README.md
+++ b/examples/messenger-persona/README.md
@@ -1,4 +1,4 @@
-# Messenger persona
+# Messenger Persona
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,13 +27,13 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
 > Note: You must set `PERSONA_1` and `PERSONA_2` env variables pairs before running this command. You can create them using `npx bottender messenger persona create --name <name> --pic <url>`.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
@@ -39,7 +41,7 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Messenger](https://www.messenger.com/) to demonstrate how to use persona API.
 
@@ -59,6 +61,6 @@ await context.sendText('hi', { persona_id: '<PERSONA_ID_2>' });
 
 For more information, check our [Messenger guides](https://bottender.js.org/docs/channel-messenger-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)

--- a/examples/messenger-typing/README.md
+++ b/examples/messenger-typing/README.md
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken`, `appSecret` and `verifyToken` into `bottender.config.js`.
+You have to put `appId`, `appSecret`, `pageId`, `accessToken` and `verifyToken` into `bottender.config.js`.
+
+If you are not familiar with Messenger Bot, you may refer to Bottender's doc, [Setup Messenger](https://bottender.js.org/docs/channel-messenger-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,11 +27,11 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/messenger` from command line.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
@@ -37,7 +39,7 @@ npx bottender messenger webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `appId`, `appSecret` and `verifyToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example shows using `withTyping` to make your bot user experience better.
 It will show typing indicator and delay all your send request for seconds. For
@@ -45,6 +47,6 @@ example, this is
 [Messenger sender action](https://developers.facebook.com/docs/messenger-platform/send-messages/sender-actions/).
 Notice that the unit of optional number of delay seconds is **millisecond**.
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)

--- a/examples/multiple-channels/README.md
+++ b/examples/multiple-channels/README.md
@@ -27,7 +27,7 @@ This command will start server for bot developing at `http://localhost:5000`.
 
 If you successfully start the server, you will get webhook urls correspond to each platform from command line.
 
-## Set webhook
+## Set Webhook
 
 You must set webhooks correspond to mounted paths properly:
 
@@ -41,13 +41,13 @@ You must set webhooks correspond to mounted paths properly:
 
 > Note: See related examples to know how to set webhook on each platform
 
-## Idea of this example
+## Idea of this Example
 
 This example shows the basic idea of building a cross-platform bot. The best
 feature of this example is that you can only develop one handler for five
 different bots, instead of developing one handler for each platform.
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)
 - [line-hello-world](../line-hello-world)

--- a/examples/session-file/README.md
+++ b/examples/session-file/README.md
@@ -11,13 +11,13 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to use Session to store some information from users and
 store sessions in your local file. For more information, check our
 [session guide](https://bottender.js.org/docs/the-basics-session).
 
-## Related examples
+## Related Examples
 
 - [session-memory](../session-memory)
 - [session-mongo](../session-mongo)

--- a/examples/session-memory/README.md
+++ b/examples/session-memory/README.md
@@ -11,13 +11,13 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to use Session to store some information from users. For
 more information, check our
 [session guide](https://bottender.js.org/docs/the-basics-session).
 
-## Related examples
+## Related Examples
 
 - [session-file](../session-file)
 - [session-mongo](../session-mongo)

--- a/examples/session-mongo/README.md
+++ b/examples/session-mongo/README.md
@@ -11,13 +11,13 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to use Session to store some information from users and
 store sessions in your MongoDB. For more information, check our
 [session guide](https://bottender.js.org/docs/the-basics-session).
 
-## Related examples
+## Related Examples
 
 - [session-memory](../session-memory)
 - [session-file](../session-file)

--- a/examples/session-redis/README.md
+++ b/examples/session-redis/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev -- --console
 ```
 
-## Redis connection settings
+## Redis Connection Settings
 
 ```js
 module.exports = {
@@ -29,13 +29,13 @@ module.exports = {
 };
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to use Session to store some information from users and
 store sessions in your Redis server. For more information, check our
 [session guide](https://bottender.js.org/docs/the-basics-session).
 
-## Related examples
+## Related Examples
 
 - [session-memory](../session-memory)
 - [session-file](../session-file)

--- a/examples/slack-hello-world/README.md
+++ b/examples/slack-hello-world/README.md
@@ -1,4 +1,4 @@
-# Slack hello world
+# Slack Hello World
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken` and `verificationToken` into `index.js`.
+You have to put `accessToken` and `verificationToken` into `bottender.config.js`.
+
+If you are not familiar with Slack Bot, you may refer to Bottender's doc, [Setup Slack](https://bottender.js.org/docs/channel-slack-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,18 +27,18 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/slack` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/slack` from command line.
 
-## Set webhook
+## Set Webhook
 
-To set the webhook, go to [Slack Developer Console](https://api.slack.com/apps) / [YourApp] / Event Subscriptions, and use the webhook url you get from running `npm run dev` to edit Request URL for your bot.
+To set the webhook, go to [Slack Developer Console](https://api.slack.com/apps) / [YourApp] / Event Subscriptions, and use the webhook URL you get from running `npm run dev` to edit Request URL for your bot.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Slack](https://slack.com/).
 For more information, check our [Slack guides](https://bottender.js.org/docs/channel-slack-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)
 - [slack-hello-world](../slack-hello-world)

--- a/examples/slack-interactive-message/README.md
+++ b/examples/slack-interactive-message/README.md
@@ -1,4 +1,4 @@
-# Slack interactive message
+# Slack Interactive Message
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken` and `verificationToken` into `index.js`.
+You have to put `accessToken` and `verificationToken` into `bottender.config.js`.
+
+If you are not familiar with Slack Bot, you may refer to Bottender's doc, [Setup Slack](https://bottender.js.org/docs/channel-slack-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,13 +27,13 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/slack` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/slack` from command line.
 
-## Set webhook
+## Set Webhook
 
-To set the webhook, go to [Slack Developer Console](https://api.slack.com/apps) / [YourApp] / Event Subscriptions, and use the webhook url you get from running `npm run dev` to edit Request URL for your bot.
+To set the webhook, go to [Slack Developer Console](https://api.slack.com/apps) / [YourApp] / Event Subscriptions, and use the webhook URL you get from running `npm run dev` to edit Request URL for your bot.
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to send [messages with interactive components (button/menu)](https://api.slack.com/interactive-messages) and handle the event triggered by users clicking the button/menu.
 
@@ -45,6 +47,6 @@ After that, type 'heyo' to the bot and it will respond you with buttons and menu
 
 ![default](https://user-images.githubusercontent.com/1003146/33164927-e2ec8da6-d06f-11e7-9378-e8a3e9b37257.png)
 
-## Related examples
+## Related Examples
 
 - [slack-hello-world](../slack-hello-world)

--- a/examples/telegram-hello-world/README.md
+++ b/examples/telegram-hello-world/README.md
@@ -1,4 +1,4 @@
-# Telegram hello world
+# Telegram Hello World
 
 ## Install and Run
 
@@ -15,7 +15,9 @@ Install dependencies:
 npm install
 ```
 
-You must put `accessToken` into `bottender.config.js`.
+You have to put `accessToken` into `bottender.config.js`.
+
+If you are not familiar with Telegram Bot, you may refer to Bottender's doc, [Setup Telegram](https://bottender.js.org/docs/channel-telegram-setup), to find detailed instructions.
 
 After that, you can run the bot with this npm script:
 
@@ -25,11 +27,11 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/slack` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/slack` from command line.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender telegram webhook set -w <YOUR_WEBHOOK_URL>
@@ -37,12 +39,12 @@ npx bottender telegram webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `accessToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Telegram](https://telegram.org/).
 For more information, check our [Telegram guides](https://bottender.js.org/docs/channel-telegram-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)
 - [line-hello-world](../line-hello-world)

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 Building a todo app is the best way to understand new tools. This example shows
 what a To-Do console bot looks like. We suggest that you read our
@@ -72,6 +72,6 @@ async function ClearTodos(context) {
 For more information about Bottender, please visit our
 [Docs Website](https://bottender.js.org/).
 
-## Related examples
+## Related Examples
 
 - [with-state](../with-state)

--- a/examples/viber-hello-world/README.md
+++ b/examples/viber-hello-world/README.md
@@ -1,4 +1,4 @@
-# Viber hello world
+# Viber Hello World
 
 ## Install and Run
 
@@ -25,11 +25,11 @@ npm run dev
 
 This command will start server for bot developing at `http://localhost:5000`.
 
-If you successfully start the server, you will get a webhook url like `https://xxxxxxxx.ngrok.io/webhooks/viber` from command line.
+If you successfully start the server, you will get a webhook URL like `https://xxxxxxxx.ngrok.io/webhooks/viber` from command line.
 
-## Set webhook
+## Set Webhook
 
-While the server running, you can run following command with `bottender` to set up the webhook with the webhook url you get from running `npm run dev`:
+While the server running, you can run following command with `bottender` to set up the webhook with the webhook URL you get from running `npm run dev`:
 
 ```sh
 npx bottender viber webhook set -w <YOUR_WEBHOOK_URL>
@@ -37,12 +37,12 @@ npx bottender viber webhook set -w <YOUR_WEBHOOK_URL>
 
 > Note: You must put `accessToken` into `bottender.config.js` before running this command.
 
-## Idea of this example
+## Idea of this Example
 
 This example is a simple bot running on [Viber](https://www.viber.com/).
 For more information, check our [Viber guides](https://bottender.js.org/docs/channel-viber-setup).
 
-## Related examples
+## Related Examples
 
 - [messenger-hello-world](../messenger-hello-world)
 - [line-hello-world](../line-hello-world)

--- a/examples/with-dialogflow/README.md
+++ b/examples/with-dialogflow/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to combine your bot with modern NLU (Natural Language Understanding) technologies. In
 this case, we take [Dialogflow](https://dialogflow.com/) as an example. Before you run

--- a/examples/with-luis.ai/README.md
+++ b/examples/with-luis.ai/README.md
@@ -11,7 +11,7 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to combine your bot with **semantic analysis tool**. In
 this case, we take [LUIS.ai](https://www.luis.ai/) as an example. Before you run

--- a/examples/with-qna-maker/README.md
+++ b/examples/with-qna-maker/README.md
@@ -11,6 +11,6 @@ npm install
 npm run dev --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to integrate your bot with [QnA Maker](https://www.qnamaker.ai/).

--- a/examples/with-rasa/README.md
+++ b/examples/with-rasa/README.md
@@ -11,6 +11,6 @@ npm install
 npm run dev -- --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to combine your bot with [Rasa NLU](https://rasa.com/docs/rasa/nlu/about/). Before you run this example, make sure you have start the Rasa Server locally on port 5005 with your NLU model following [The official Guide](https://rasa.com/docs/rasa/nlu/using-nlu-only/).

--- a/examples/with-state/README.md
+++ b/examples/with-state/README.md
@@ -11,13 +11,13 @@ npm install
 npm run dev --console
 ```
 
-## Idea of this example
+## Idea of this Example
 
 This example shows how to use Session State to store some information from
 users. For more information, check our
 [session guide](https://bottender.js.org/docs/the-basics-session).
 
-## Related examples
+## Related Examples
 
 - [session-memory](../session-memory)
 - [session-file](../session-file)


### PR DESCRIPTION
1. Make sure all config files of examples is `bottender.config.js`
2. Change all headings to title case
4. unify all `url` to `URL` (based on Grammarly's suggestion)
5. Add hyperlink of setup doc to chat channel specific examples
