### PR TITLE
fix(Bot, LineConnector, MessengerConnector): when receiving multiple events, construct session with event instead of request

### DIFF
--- a/packages/bottender/src/bot/Connector.ts
+++ b/packages/bottender/src/bot/Connector.ts
@@ -1,16 +1,20 @@
 import EventEmitter from 'events';
 
 import Session from '../session/Session';
+import { Event } from '../context/Event';
 import { RequestContext } from '../types';
 
 export interface Connector<B, C> {
   client: C;
   platform: string;
-  getUniqueSessionKey(body: B, requestContext?: RequestContext): string | null;
-  updateSession(session: Session, body: B): Promise<void>;
-  mapRequestToEvents(body: B): any[];
+  getUniqueSessionKey(
+    bodyOrEvent: B | Event<any>,
+    requestContext?: RequestContext
+  ): string | null;
+  updateSession(session: Session, bodyOrEvent: B | Event<any>): Promise<void>;
+  mapRequestToEvents(body: B): Event<any>[];
   createContext(params: {
-    event: any;
+    event: Event<any>;
     session?: Session | null;
     initialState?: Record<string, any> | null;
     requestContext?: RequestContext;

--- a/packages/bottender/src/line/LineConnector.ts
+++ b/packages/bottender/src/line/LineConnector.ts
@@ -123,8 +123,14 @@ export default class LineConnector
     return this._client;
   }
 
-  getUniqueSessionKey(body: LineRequestBody): string {
-    const { source } = body.events[0];
+  getUniqueSessionKey(bodyOrEvent: LineRequestBody | LineEvent): string {
+    const rawEvent =
+      bodyOrEvent instanceof LineEvent
+        ? bodyOrEvent.rawEvent
+        : bodyOrEvent.events[0];
+
+    const { source } = rawEvent;
+
     if (source.type === 'user') {
       return source.userId;
     }
@@ -139,8 +145,16 @@ export default class LineConnector
     );
   }
 
-  async updateSession(session: Session, body: LineRequestBody): Promise<void> {
-    const { source } = body.events[0];
+  async updateSession(
+    session: Session,
+    bodyOrEvent: LineRequestBody | LineEvent
+  ): Promise<void> {
+    const rawEvent =
+      bodyOrEvent instanceof LineEvent
+        ? bodyOrEvent.rawEvent
+        : bodyOrEvent.events[0];
+
+    const { source } = rawEvent;
 
     if (!session.type) {
       session.type = source.type;

--- a/packages/bottender/src/line/__tests__/LineConnector.spec.ts
+++ b/packages/bottender/src/line/__tests__/LineConnector.spec.ts
@@ -131,7 +131,7 @@ describe('#getUniqueSessionKey', () => {
     expect(senderId).toBe('U206d25c2ea6bd87c17655609a1c37cb8');
   });
 
-  it('extract groupId from user source', () => {
+  it('extract groupId from group source', () => {
     const { connector } = setup();
     const senderId = connector.getUniqueSessionKey({
       events: [
@@ -154,7 +154,7 @@ describe('#getUniqueSessionKey', () => {
     expect(senderId).toBe('U206d25c2ea6bd87c17655609a1c37cb8');
   });
 
-  it('extract roomId from user source', () => {
+  it('extract roomId from room source', () => {
     const { connector } = setup();
     const senderId = connector.getUniqueSessionKey({
       events: [
@@ -174,6 +174,27 @@ describe('#getUniqueSessionKey', () => {
         },
       ],
     });
+    expect(senderId).toBe('U206d25c2ea6bd87c17655609a1c37cb8');
+  });
+
+  it('extract from line event', () => {
+    const { connector } = setup();
+    const senderId = connector.getUniqueSessionKey(
+      new LineEvent({
+        replyToken: 'nHuyWiB7yP5Zw52FIkcQobQuGDXCTA',
+        type: 'message',
+        timestamp: 1462629479859,
+        source: {
+          type: 'user',
+          userId: 'U206d25c2ea6bd87c17655609a1c37cb8',
+        },
+        message: {
+          id: '325708',
+          type: 'text',
+          text: 'Hello, world',
+        },
+      })
+    );
     expect(senderId).toBe('U206d25c2ea6bd87c17655609a1c37cb8');
   });
 

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -242,8 +242,13 @@ export default class MessengerConnector
     return this._verifyToken;
   }
 
-  getUniqueSessionKey(body: MessengerRequestBody): string | null {
-    const rawEvent = this._getRawEventsFromRequest(body)[0];
+  getUniqueSessionKey(
+    bodyOrEvent: MessengerRequestBody | MessengerEvent
+  ): string | null {
+    const rawEvent =
+      bodyOrEvent instanceof MessengerEvent
+        ? bodyOrEvent.rawEvent
+        : this._getRawEventsFromRequest(bodyOrEvent)[0];
     if (
       rawEvent &&
       rawEvent.message &&
@@ -260,12 +265,17 @@ export default class MessengerConnector
 
   async updateSession(
     session: Session,
-    body: MessengerRequestBody
+    bodyOrEvent: MessengerRequestBody | MessengerEvent
   ): Promise<void> {
     if (!session.user || this._profilePicExpired(session.user)) {
-      const senderId = this.getUniqueSessionKey(body);
+      const senderId = this.getUniqueSessionKey(bodyOrEvent);
 
-      const rawEvent = this._getRawEventsFromRequest(body)[0];
+      const rawEvent =
+        bodyOrEvent instanceof MessengerEvent
+          ? bodyOrEvent.rawEvent
+          : this._getRawEventsFromRequest(bodyOrEvent)[0];
+
+      // TODO: use this info from event
       const pageId = this._getPageIdFromRawEvent(rawEvent);
       let customAccessToken;
 

--- a/packages/bottender/src/messenger/__tests__/MessengerConnector.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/MessengerConnector.spec.ts
@@ -260,6 +260,27 @@ describe('#getUniqueSessionKey', () => {
     const senderId = connector.getUniqueSessionKey(webhookTestRequest.body);
     expect(senderId).toBe(null);
   });
+
+  it('extract from messenger event', () => {
+    const { connector } = setup();
+    const senderId = connector.getUniqueSessionKey(
+      new MessengerEvent({
+        sender: {
+          id: '1412611362105802',
+        },
+        recipient: {
+          id: '1895382890692545',
+        },
+        timestamp: 1486464322190,
+        message: {
+          mid: 'mid.1486464322190:cb04e5a654',
+          seq: 339979,
+          text: 'text',
+        },
+      })
+    );
+    expect(senderId).toBe('1412611362105802');
+  });
 });
 
 describe('#updateSession', () => {


### PR DESCRIPTION
fix #240

In this PR, I don't want to introduce any breaking changes to Connector API interface, so It's acceptable to support both request body and event in `LineConnector` and `MessengerConnector`. (support request body as parameter until v2)

Todo:
- [x] Add tests

