### PR TITLE
feat: add getSessionStore api

### DIFF
--- a/packages/bottender/src/__tests__/getSessionStore.spec.ts
+++ b/packages/bottender/src/__tests__/getSessionStore.spec.ts
@@ -1,0 +1,74 @@
+import getBottenderConfig from '../shared/getBottenderConfig';
+import getSessionStore from '../getSessionStore';
+import { SessionDriver } from '../types';
+
+jest.mock('../shared/getBottenderConfig');
+
+const getBottenderConfigMocked = getBottenderConfig as jest.MockedFunction<
+  typeof getBottenderConfig
+>;
+
+it('should get MemorySessionStore by default', () => {
+  getBottenderConfigMocked.mockReturnValueOnce({});
+  expect(getSessionStore().constructor.name).toEqual('MemorySessionStore');
+});
+
+it('should get MemorySessionStore when assigning memory as driver', () => {
+  getBottenderConfigMocked.mockReturnValueOnce({
+    session: {
+      driver: SessionDriver.Memory,
+      stores: {
+        memory: {
+          maxSize: 500,
+        },
+      },
+    },
+  });
+  expect(getSessionStore().constructor.name).toEqual('MemorySessionStore');
+});
+
+it('should get FileSessionStore when assigning file as driver', () => {
+  getBottenderConfigMocked.mockReturnValueOnce({
+    session: {
+      driver: SessionDriver.File,
+      stores: {
+        file: {
+          dirname: '.sessions',
+        },
+      },
+    },
+  });
+  expect(getSessionStore().constructor.name).toEqual('FileSessionStore');
+});
+
+it('should get MongoSessionStore when assigning mongo as driver', () => {
+  getBottenderConfigMocked.mockReturnValueOnce({
+    session: {
+      driver: SessionDriver.Mongo,
+      stores: {
+        mongo: {
+          url: 'mongodb://localhost:27017',
+          collectionName: 'sessions',
+        },
+      },
+    },
+  });
+  expect(getSessionStore().constructor.name).toEqual('MongoSessionStore');
+});
+
+it('should get RedisSessionStore when assigning redis as driver', () => {
+  getBottenderConfigMocked.mockReturnValueOnce({
+    session: {
+      driver: SessionDriver.Redis,
+      stores: {
+        redis: {
+          port: 6379,
+          host: '127.0.0.1',
+          password: 'auth',
+          db: 0,
+        },
+      },
+    },
+  });
+  expect(getSessionStore().constructor.name).toEqual('RedisSessionStore');
+});

--- a/packages/bottender/src/__tests__/index.spec.ts
+++ b/packages/bottender/src/__tests__/index.spec.ts
@@ -51,6 +51,10 @@ describe('core', () => {
     expect(core.createServer).toBeDefined();
   });
 
+  it('export getSessionStore', () => {
+    expect(core.getSessionStore).toBeDefined();
+  });
+
   it('export chain', () => {
     expect(core.chain).toBeDefined();
   });

--- a/packages/bottender/src/getSessionStore.ts
+++ b/packages/bottender/src/getSessionStore.ts
@@ -1,0 +1,64 @@
+import warning from 'warning';
+
+import getBottenderConfig from './shared/getBottenderConfig';
+
+function getSessionStore() {
+  const bottenderConfig = getBottenderConfig();
+
+  const { session } = bottenderConfig;
+
+  const sessionDriver = (session && session.driver) || 'memory';
+
+  const storesConfig = (session && session.stores) || {};
+
+  switch (sessionDriver) {
+    case 'memory': {
+      const MemorySessionStore = require('./session/MemorySessionStore')
+        .default;
+
+      return new MemorySessionStore(
+        storesConfig.memory || {},
+        session && session.expiresIn
+      );
+    }
+    case 'file': {
+      const FileSessionStore = require('./session/FileSessionStore').default;
+
+      return new FileSessionStore(
+        storesConfig.file || {},
+        session && session.expiresIn
+      );
+    }
+    case 'mongo': {
+      const MongoSessionStore = require('./session/MongoSessionStore').default;
+
+      return new MongoSessionStore(
+        storesConfig.mongo || {},
+        session && session.expiresIn
+      );
+    }
+    case 'redis': {
+      const RedisSessionStore = require('./session/RedisSessionStore').default;
+
+      return new RedisSessionStore(
+        storesConfig.redis || {},
+        session && session.expiresIn
+      );
+    }
+    default: {
+      warning(
+        false,
+        `Received unknown driver: ${sessionDriver}, so fallback it to \`memory\` driver.`
+      );
+      const MemorySessionStore = require('./session/MemorySessionStore')
+        .default;
+
+      return new MemorySessionStore(
+        storesConfig.memory || {},
+        session && session.expiresIn
+      );
+    }
+  }
+}
+
+export default getSessionStore;

--- a/packages/bottender/src/index.ts
+++ b/packages/bottender/src/index.ts
@@ -5,6 +5,7 @@ export { bottender };
 /* Core */
 export { default as Bot } from './bot/Bot';
 export { default as Context } from './context/Context';
+export { default as getSessionStore } from './getSessionStore';
 
 /* Action */
 export { default as chain } from './chain';

--- a/packages/bottender/src/initializeServer.ts
+++ b/packages/bottender/src/initializeServer.ts
@@ -11,6 +11,7 @@ import SlackBot from './slack/SlackBot';
 import TelegramBot from './telegram/TelegramBot';
 import ViberBot from './viber/ViberBot';
 import getBottenderConfig from './shared/getBottenderConfig';
+import getSessionStore from './getSessionStore';
 import { Action, BottenderConfig, Channel, Plugin } from './types';
 
 const BOT_MAP = {
@@ -30,35 +31,9 @@ function initializeServer({
 } = {}): express.Application | void {
   const bottenderConfig = getBottenderConfig();
 
-  const { initialState, plugins, session, channels } = merge(
-    bottenderConfig,
-    config
-  );
+  const { initialState, plugins, channels } = merge(bottenderConfig, config);
 
-  // session
-  const sessionDriver = (session && session.driver) || 'memory';
-  let SessionStore;
-  switch (sessionDriver) {
-    case 'file':
-      SessionStore = require('./session/FileSessionStore').default;
-      break;
-    case 'mongo':
-      SessionStore = require('./session/MongoSessionStore').default;
-      break;
-    case 'redis':
-      SessionStore = require('./session/RedisSessionStore').default;
-      break;
-    default:
-      SessionStore = require('./session/MemorySessionStore').default;
-  }
-
-  const sessionDriverConfig =
-    ((session && session.stores) || {})[sessionDriver] || {};
-
-  const sessionStore = new SessionStore(
-    sessionDriverConfig,
-    session && session.expiresIn
-  );
+  const sessionStore = getSessionStore();
 
   // TODO: refine handler entry, improve error message and hint
   // eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-var-requires

--- a/packages/bottender/src/server/Server.ts
+++ b/packages/bottender/src/server/Server.ts
@@ -8,46 +8,13 @@ import { pascalcase } from 'messaging-api-common';
 
 import Bot from '../bot/Bot';
 import getBottenderConfig from '../shared/getBottenderConfig';
-import {
-  Action,
-  BottenderConfig,
-  Plugin,
-  SessionConfig,
-  SessionDriver,
-} from '../types';
+import getSessionStore from '../getSessionStore';
+import { Action, BottenderConfig, Plugin } from '../types';
 
 export type ServerOptions = {
   useConsole?: boolean;
   dev?: boolean;
 };
-
-function createSessionStore(
-  sessionConfig: SessionConfig = { driver: SessionDriver.Memory, stores: {} }
-) {
-  const sessionDriver = (sessionConfig && sessionConfig.driver) || 'memory';
-  let SessionStore;
-  switch (sessionDriver) {
-    case 'file':
-      SessionStore = require('../session/FileSessionStore').default;
-      break;
-    case 'mongo':
-      SessionStore = require('../session/MongoSessionStore').default;
-      break;
-    case 'redis':
-      SessionStore = require('../session/RedisSessionStore').default;
-      break;
-    default:
-      SessionStore = require('../session/MemorySessionStore').default;
-  }
-
-  const sessionDriverConfig =
-    ((sessionConfig && sessionConfig.stores) || {})[sessionDriver] || {};
-
-  return new SessionStore(
-    sessionDriverConfig,
-    sessionConfig && sessionConfig.expiresIn
-  );
-}
 
 class Server {
   _channelBots: { webhookPath: string; bot: Bot<any, any, any> }[] = [];
@@ -73,11 +40,11 @@ class Server {
   public async prepare(): Promise<void> {
     const bottenderConfig = getBottenderConfig();
 
-    const { initialState, plugins, session, channels } = merge(
+    const { initialState, plugins, channels } = merge(
       bottenderConfig /* , config */
     ) as BottenderConfig;
 
-    const sessionStore = createSessionStore(session);
+    const sessionStore = getSessionStore();
 
     // TODO: refine handler entry, improve error message and hint
     // eslint-disable-next-line import/no-dynamic-require, @typescript-eslint/no-var-requires

--- a/packages/bottender/src/session/MongoSessionStore.ts
+++ b/packages/bottender/src/session/MongoSessionStore.ts
@@ -8,7 +8,7 @@ import SessionStore from './SessionStore';
 type MongoOption =
   | string
   | {
-      url: string;
+      url?: string;
       collectionName?: string;
     };
 
@@ -27,7 +27,7 @@ export default class MongoSessionStore implements SessionStore {
       this._url = options;
       this._collectionName = 'sessions';
     } else {
-      this._url = options.url;
+      this._url = options.url || 'mongodb://localhost:27017';
       this._collectionName = options.collectionName || 'sessions';
     }
     this._expiresIn = expiresIn || 0;

--- a/packages/bottender/src/types.ts
+++ b/packages/bottender/src/types.ts
@@ -86,10 +86,10 @@ export type SessionConfig = {
       port?: number;
       host?: string;
       password?: string;
-      db: number;
+      db?: number;
     };
     mongo?: {
-      url: string;
+      url?: string;
       collectionName?: string;
     };
   };


### PR DESCRIPTION
Added following API to get the session store that configured by `bottender.config.js`

```js
const { getSessionStore } = require('bottender');

const sessionStore = getSessionStore();
```