### PR TITLE
feat: implement getClient helper function

### DIFF
--- a/docs/channel-messenger-multi-page.md
+++ b/docs/channel-messenger-multi-page.md
@@ -95,11 +95,9 @@ We recommend you at least enable the following fields:
 We assume that you might need to add your bot to a Facebook Pages dynamically. In the following code, you can see how to subscribe `Facebook Page Subscriptions Fields` your bot needs.
 
 ```js
-const { MessengerClient } = require('messaging-api-messenger');
+const { getClient } = require('bottender');
 
-const config = require('./bottender.config.js');
-
-const messenger = new MessengerClient(config.channels.messenger);
+const messenger = getClient('messenger');
 
 // subscribe app for page
 await messenger.axios.post(

--- a/packages/bottender/src/__tests__/index.spec.ts
+++ b/packages/bottender/src/__tests__/index.spec.ts
@@ -55,6 +55,10 @@ describe('core', () => {
     expect(core.getSessionStore).toBeDefined();
   });
 
+  it('export getClient', () => {
+    expect(core.getClient).toBeDefined();
+  });
+
   it('export chain', () => {
     expect(core.chain).toBeDefined();
   });

--- a/packages/bottender/src/getClient.ts
+++ b/packages/bottender/src/getClient.ts
@@ -1,0 +1,38 @@
+import LineBot from './line/LineBot';
+import MessengerBot from './messenger/MessengerBot';
+import SlackBot from './slack/SlackBot';
+import TelegramBot from './telegram/TelegramBot';
+import ViberBot from './viber/ViberBot';
+import getBottenderConfig from './shared/getBottenderConfig';
+import getSessionStore from './getSessionStore';
+import { Channel } from './types';
+
+const BOT_MAP = {
+  messenger: MessengerBot,
+  line: LineBot,
+  slack: SlackBot,
+  telegram: TelegramBot,
+  viber: ViberBot,
+};
+
+function getClient(channel: Channel) {
+  const { channels = {} } = getBottenderConfig();
+  const sessionStore = getSessionStore();
+
+  const channelConfig = (channels as any)[channel];
+
+  if (!channelConfig) {
+    return null;
+  }
+
+  const ChannelBot = BOT_MAP[channel];
+
+  const channelBot = new ChannelBot({
+    ...channelConfig,
+    sessionStore,
+  } as any);
+
+  return channelBot.connector.client;
+}
+
+export default getClient;

--- a/packages/bottender/src/getSessionStore.ts
+++ b/packages/bottender/src/getSessionStore.ts
@@ -3,9 +3,7 @@ import warning from 'warning';
 import getBottenderConfig from './shared/getBottenderConfig';
 
 function getSessionStore() {
-  const bottenderConfig = getBottenderConfig();
-
-  const { session } = bottenderConfig;
+  const { session } = getBottenderConfig();
 
   const sessionDriver = (session && session.driver) || 'memory';
 

--- a/packages/bottender/src/index.ts
+++ b/packages/bottender/src/index.ts
@@ -6,6 +6,7 @@ export { bottender };
 export { default as Bot } from './bot/Bot';
 export { default as Context } from './context/Context';
 export { default as getSessionStore } from './getSessionStore';
+export { default as getClient } from './getClient';
 
 /* Action */
 export { default as chain } from './chain';


### PR DESCRIPTION
Add this helper to access underlying messaging client configured by `bottender.config.js`:

```js
const { getClient } = require('bottender');

const messenger = getClient('messenger');

messenger.sendText(USER_ID, 'Hello!', { tag: 'CONFIRMED_EVENT_UPDATE' });

const line = getClient('line');

line.pushText(USER_ID, 'Hello!');
```
