### PR TITLE
feat(slack): add includeBotMessages option for interacting with bot_message

### DIFF
--- a/packages/bottender/src/slack/SlackBot.ts
+++ b/packages/bottender/src/slack/SlackBot.ts
@@ -21,19 +21,22 @@ export default class SlackBot extends Bot<
     verificationToken,
     origin,
     skipLegacyProfile,
+    includeBotMessages,
   }: {
     accessToken: string;
     sessionStore?: SessionStore;
     sync?: boolean;
     verificationToken?: string;
     origin?: string;
-    skipLegacyProfile?: boolean | null;
+    skipLegacyProfile?: boolean;
+    includeBotMessages?: boolean;
   }) {
     const connector = new SlackConnector({
       accessToken,
       verificationToken,
       origin,
       skipLegacyProfile,
+      includeBotMessages,
     });
     super({ connector, sessionStore, sync });
     this._accessToken = accessToken;

--- a/packages/bottender/src/slack/SlackEvent.ts
+++ b/packages/bottender/src/slack/SlackEvent.ts
@@ -278,6 +278,14 @@ export default class SlackEvent implements Event<SlackRawEvent> {
     }
     return null;
   }
+
+  /**
+   * Determine if the event is a bot message event.
+   *
+   */
+  get isBotMessage(): boolean {
+    return (this._rawEvent as any).subtype === 'bot_message';
+  }
 }
 
 // https://api.slack.com/events

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -150,6 +150,7 @@ const RtmMessage = {
 function setup({
   verificationToken = 'xxxxxxxxxxxxxxxxxxxxxxxxxxx',
   skipLegacyProfile,
+  includeBotMessages,
 } = {}) {
   const mockSlackOAuthClient = {
     getUserInfo: jest.fn(),
@@ -164,6 +165,7 @@ function setup({
       accessToken,
       verificationToken,
       skipLegacyProfile,
+      includeBotMessages,
     }),
     mockSlackOAuthClient,
   };
@@ -392,6 +394,23 @@ describe('#mapRequestToEvents', () => {
   it('should map request to SlackEvents', () => {
     const { connector } = setup();
     const events = connector.mapRequestToEvents(request.body);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBeInstanceOf(SlackEvent);
+  });
+
+  it('should not include bot message by default', () => {
+    const { connector } = setup();
+    const events = connector.mapRequestToEvents(botRequest.body);
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('should include bot message when includeBotMessages is true', () => {
+    const { connector } = setup({
+      includeBotMessages: true,
+    });
+    const events = connector.mapRequestToEvents(botRequest.body);
 
     expect(events).toHaveLength(1);
     expect(events[0]).toBeInstanceOf(SlackEvent);

--- a/packages/bottender/src/slack/__tests__/SlackEvent.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackEvent.spec.ts
@@ -272,6 +272,16 @@ const message = {
   ts: '1355517523.000005',
 };
 
+const botMessage = {
+  type: 'message',
+  subtype: 'bot_message',
+  ts: '1358877455.000010',
+  text: 'Pushing is the answer',
+  botId: 'BB12033',
+  username: 'github',
+  icons: {},
+};
+
 const channelsMessage = {
   type: 'message',
   channel: 'C2147483705',
@@ -893,4 +903,9 @@ describe('interactive message event', () => {
     });
     expect(new SlackEvent(message).action).toEqual(null);
   });
+});
+
+it('#isBotMessage', () => {
+  expect(new SlackEvent(message).isBotMessage).toEqual(false);
+  expect(new SlackEvent(botMessage).isBotMessage).toEqual(true);
 });


### PR DESCRIPTION
#625

Implement the following API to interact with `bot_message`:

Set `includeBotMessages` to `true`

```js
// bottender.config.js

module.exports = {
  // ...
  slack: {
    enabled: true,
    path: '/webhooks/slack',
    accessToken: process.env.SLACK_ACCESS_TOKEN,
    verificationToken: process.env.SLACK_VERIFICATION_TOKEN,
    includeBotMessages: true, // add this line
  },
};
```

Use `context.event.isBotMessage` to determine if the event is a bot message event:

```js
module.exports = function App(context) {
  if (context.event.isBotMessage) {
    console.log(context.event.rawEvent.botId);
  }
};
```