### PR TITLE
feat (slack): support slack signing secret

### DIFF
--- a/docs/advanced-guides-multi-channel.md
+++ b/docs/advanced-guides-multi-channel.md
@@ -81,7 +81,7 @@ module.exports = {
       enabled: true,
       path: '/webhooks/slack',
       accessToken: process.env.SLACK_ACCESS_TOKEN,
-      verificationToken: process.env.SLACK_VERIFICATION_TOKEN,
+      signingSecret: process.env.SLACK_SIGNING_SECRET,
     },
     viber: {
       enabled: true,

--- a/docs/channel-slack-setup.md
+++ b/docs/channel-slack-setup.md
@@ -34,7 +34,8 @@ module.exports = {
       enabled: true,
       path: '/webhooks/slack',
       accessToken: process.env.SLACK_ACCESS_TOKEN,
-      verificationToken: process.env.SLACK_VERIFICATION_TOKEN,
+      signingSecret: process.env.SLACK_SIGNING_SECRET,
+      // verificationToken: process.env.SLACK_VERIFICATION_TOKEN, // deprecated, use signingSecret
     },
   },
 };
@@ -47,7 +48,7 @@ The default webhook path is `/webhooks/slack`, but you can set your webhook path
 To make a Slack bot work, you have to set up the following values:
 
 - Slack Access Token
-- Slack Verification Token
+- Slack Signing Secret (or Verification Token)
 - Webhook
 
 ### Requirements
@@ -79,7 +80,7 @@ Remember to install the Slack App in your workspace.
 >
 > - If you are not familiar with how Slack bots work, you can find detailed instructions from DialogFlow's [Slack Integration Document](https://cloud.google.com/dialogflow/docs/integrations/slack)
 
-### Access Token & Verification Token
+### Access Token & Signing Secret (or Verification Token)
 
 `bottender.config.js` looks up `.env` for Slack access token and Slack verification token.
 
@@ -87,16 +88,23 @@ Remember to install the Slack App in your workspace.
 // .env
 
 SLACK_ACCESS_TOKEN=
-SLACK_VERIFICATION_TOKEN=
+SLACK_SIGNING_SECRET=
+# SLACK_VERIFICATION_TOKEN= # deprecated, use SLACK_SIGNING_SECRET
 ```
 
-Follow the below steps to find your access token and verification token.
+Follow the below steps to find your access token and signing secret (or verification token).
 
 - Slack access token could is in [Slack Developer Console](https://api.slack.com/apps) → \${YourApp} → Install App → Bot User OAuth Access Token
 
 <p><img width="800" src="https://user-images.githubusercontent.com/662387/71455592-a7cafb80-27d0-11ea-8ac7-3633c2b4d429.png"></p>
 
-- Slack verification token could is in [Slack Developer Console](https://api.slack.com/apps) → \${YourApp} → Basic Information → Verification Token.
+- Slack signing secret could be find in [Slack Developer Console](https://api.slack.com/apps) → \${YourApp} → Basic Information → Signing Secret.
+
+<p><img width="800" src="https://user-images.githubusercontent.com/4010549/74005498-07155180-49b4-11ea-9f15-f2e0e869f677.png"></p>
+
+We recommend use signing secret instead of verification token, but we also support verification token:
+
+- Slack verification token could be find in [Slack Developer Console](https://api.slack.com/apps) → \${YourApp} → Basic Information → Verification Token.
 
 <p><img width="800" src="https://user-images.githubusercontent.com/662387/71443865-668f0900-2748-11ea-9637-158575626c53.png"></p>
 

--- a/docs/channel-slack-setup.md
+++ b/docs/channel-slack-setup.md
@@ -98,7 +98,7 @@ Follow the below steps to find your access token and signing secret (or verifica
 
 <p><img width="800" src="https://user-images.githubusercontent.com/662387/71455592-a7cafb80-27d0-11ea-8ac7-3633c2b4d429.png"></p>
 
-- Slack signing secret could be find in [Slack Developer Console](https://api.slack.com/apps) → \${YourApp} → Basic Information → Signing Secret.
+- Slack signing secret could be found in [Slack Developer Console](https://api.slack.com/apps) → \${YourApp} → Basic Information → Signing Secret.
 
 <p><img width="800" src="https://user-images.githubusercontent.com/4010549/74005498-07155180-49b4-11ea-9f15-f2e0e869f677.png"></p>
 

--- a/packages/bottender/src/slack/SlackBot.ts
+++ b/packages/bottender/src/slack/SlackBot.ts
@@ -19,6 +19,7 @@ export default class SlackBot extends Bot<
     sessionStore,
     sync,
     verificationToken,
+    signingSecret,
     origin,
     skipLegacyProfile,
     includeBotMessages,
@@ -27,6 +28,7 @@ export default class SlackBot extends Bot<
     sessionStore?: SessionStore;
     sync?: boolean;
     verificationToken?: string;
+    signingSecret?: string;
     origin?: string;
     skipLegacyProfile?: boolean;
     includeBotMessages?: boolean;
@@ -34,6 +36,7 @@ export default class SlackBot extends Bot<
     const connector = new SlackConnector({
       accessToken,
       verificationToken,
+      signingSecret,
       origin,
       skipLegacyProfile,
       includeBotMessages,

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -40,6 +40,7 @@ export type SlackRequestBody = EventsAPIBody | { payload: string };
 type CommonConstructorOptions = {
   skipLegacyProfile?: boolean;
   verificationToken?: string;
+  signingSecret?: string;
   includeBotMessages?: boolean;
 };
 
@@ -62,6 +63,8 @@ export default class SlackConnector
 
   _verificationToken: string;
 
+  _signingSecret: string;
+
   _skipLegacyProfile: boolean;
 
   _includeBotMessages: boolean;
@@ -71,6 +74,7 @@ export default class SlackConnector
       verificationToken,
       skipLegacyProfile,
       includeBotMessages,
+      signingSecret,
     } = options;
     if ('client' in options) {
       this._client = options.client;
@@ -79,7 +83,7 @@ export default class SlackConnector
 
       invariant(
         accessToken,
-        'Viber access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
+        'Slack access token is required. Please make sure you have filled it correctly in `bottender.config.js` or `.env` file.'
       );
 
       this._client = SlackOAuthClient.connect({
@@ -88,6 +92,7 @@ export default class SlackConnector
       });
     }
 
+    this._signingSecret = signingSecret || '';
     this._verificationToken = verificationToken || '';
 
     if (!this._verificationToken) {
@@ -346,9 +351,40 @@ export default class SlackConnector
     return crypto.timingSafeEqual(bufferFromBot, bufferFromBody);
   }
 
+  verifySignatureBySigningSecret({
+    rawBody,
+    signature,
+    timestamp,
+  }: {
+    rawBody: string;
+    signature: string;
+    timestamp: number;
+  }): boolean {
+    // ignore this request if the timestamp is 5 more minutes away from now
+    if (Math.abs(Date.now() - timestamp)) {
+      return false;
+    }
+
+    const SIGNATURE_VERSION = 'v0'; // currently it's always 'v0'
+    const signatureBaseString = `${SIGNATURE_VERSION}:${timestamp}:${rawBody}`;
+
+    const digest = crypto
+      .createHmac('sha256', this._signingSecret)
+      .update(signatureBaseString, 'utf8')
+      .digest('hex');
+    const calculatedSignature = `${SIGNATURE_VERSION}=${digest}`;
+
+    return crypto.timingSafeEqual(
+      Buffer.from(signature, 'utf8'),
+      Buffer.from(calculatedSignature, 'utf8')
+    );
+  }
+
   preprocess({
     method,
+    headers,
     body,
+    rawBody,
   }: {
     method: string;
     headers: Record<string, any>;
@@ -362,12 +398,39 @@ export default class SlackConnector
       };
     }
 
+    const timestamp = headers['X-Slack-Request-Timestamp'];
+    const signature = headers['X-Slack-Signature'];
+
+    if (
+      this._signingSecret &&
+      !this.verifySignatureBySigningSecret({
+        rawBody,
+        timestamp,
+        signature,
+      })
+    ) {
+      const error = {
+        message: 'Slack Signing Secret Validation Failed!',
+        request: {
+          body,
+        },
+      };
+
+      return {
+        shouldNext: false,
+        response: {
+          status: 400,
+          body: { error },
+        },
+      };
+    }
+
     const token =
       !body.token && body.payload && typeof body.payload === 'string'
         ? JSON.parse(body.payload).token
         : body.token;
 
-    if (!this.verifySignature(token)) {
+    if (this._verificationToken && !this.verifySignature(token)) {
       const error = {
         message: 'Slack Verification Token Validation Failed!',
         request: {

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -361,7 +361,11 @@ export default class SlackConnector
     timestamp: number;
   }): boolean {
     // ignore this request if the timestamp is 5 more minutes away from now
-    if (Math.abs(Date.now() - timestamp)) {
+    const FIVE_MINUTES_IN_MILLISECONDS = 5 * 1000 * 60;
+
+    if (
+      Math.abs(Date.now() - timestamp * 1000) > FIVE_MINUTES_IN_MILLISECONDS
+    ) {
       return false;
     }
 
@@ -372,6 +376,7 @@ export default class SlackConnector
       .createHmac('sha256', this._signingSecret)
       .update(signatureBaseString, 'utf8')
       .digest('hex');
+
     const calculatedSignature = `${SIGNATURE_VERSION}=${digest}`;
 
     return crypto.timingSafeEqual(
@@ -398,8 +403,8 @@ export default class SlackConnector
       };
     }
 
-    const timestamp = headers['X-Slack-Request-Timestamp'];
-    const signature = headers['X-Slack-Signature'];
+    const timestamp = headers['x-slack-request-timestamp'];
+    const signature = headers['x-slack-signature'];
 
     if (
       this._signingSecret &&

--- a/packages/bottender/src/types.ts
+++ b/packages/bottender/src/types.ts
@@ -123,7 +123,8 @@ export type BottenderConfig = {
       enabled: boolean;
       path: string;
       accessToken: string;
-      verificationToken: string;
+      verificationToken?: string;
+      signingSecret?: string;
     };
     [Channel.Viber]: {
       enabled: boolean;


### PR DESCRIPTION
Just add request signing verification feature for Slack bot.

This bot server now verifies requests from slack platform with either `signingSecret` or `verificationToken` specified in `bottender.config.js`.  `signingSecret` takes place prior to `verificationToken` since [the latter is announced to be deprecated in the future](https://api.slack.com/docs/verifying-requests-from-slack#verification_token_deprecation).

ref: https://api.slack.com/docs/verifying-requests-from-slack

tests and docs to be added.