### PR TITLE
fix (slack): fix bugs in slack request signing

### DIFF
--- a/packages/bottender-express/src/createServer.ts
+++ b/packages/bottender-express/src/createServer.ts
@@ -7,7 +7,15 @@ import { Bot, RouteConfig } from './types';
 function createServer(bot: Bot, config: RouteConfig = {}) {
   const server = express();
 
-  server.use(bodyParser.urlencoded({ extended: false }));
+  server.use(
+    bodyParser.urlencoded({
+      extended: false,
+      verify: (req: express.Request & { rawBody?: string }, _, buf) => {
+        req.rawBody = buf.toString();
+      },
+    })
+  );
+
   server.use(
     bodyParser.json({
       verify: (req: express.Request & { rawBody?: string }, _, buf) => {

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -96,11 +96,18 @@ export default class SlackConnector
     this._signingSecret = signingSecret || '';
     this._verificationToken = verificationToken || '';
 
-    if (!this._verificationToken) {
-      warning(
-        false,
-        '`verificationToken` is not set. Will bypass Slack event verification.\nPass in `verificationToken` to perform Slack event verification.'
-      );
+    if (!this._signingSecret) {
+      if (!this._verificationToken) {
+        warning(
+          false,
+          'Both `signingSecret` and `verificationToken` is not set. Will bypass Slack event verification.\nPass in `signingSecret` to perform Slack event verification.'
+        );
+      } else {
+        warning(
+          false,
+          "It's deprecated to use `verificationToken` here, use `signingSecret` instead."
+        );
+      }
     }
 
     this._skipLegacyProfile =


### PR DESCRIPTION
1. Keep raw body after urlencoded parsing to support requests from slack (e.g. slash command) which use this kind of body format
2. fix warning message for missing request signing