### PR TITLE
feat: support `bottender dev --inspect=HOST:PORT`

### DIFF
--- a/packages/bottender/src/cli/providers/sh/dev.ts
+++ b/packages/bottender/src/cli/providers/sh/dev.ts
@@ -13,6 +13,7 @@ const dev = async (ctx: CliContext): Promise<void> => {
   const argv = getSubArgs(ctx.argv, {
     '--console': Boolean,
     '--port': Number,
+    '--inspect': String,
 
     // Aliases
     '-c': '--console',
@@ -21,6 +22,7 @@ const dev = async (ctx: CliContext): Promise<void> => {
 
   const isConsole = argv['--console'] || false;
   const port = argv['--port'] || process.env.PORT || 5000;
+  const inspectionUrl = argv['--inspect'];
 
   const config = getBottenderConfig();
 
@@ -31,6 +33,7 @@ const dev = async (ctx: CliContext): Promise<void> => {
   // watch
   nodemon(
     [
+      inspectionUrl ? `--inspect=${inspectionUrl} -- ` : '',
       isTypescript ? '--ext js,mjs,json,ts --ignore dist/ ' : '',
       '--exec "',
       isTypescript ? 'tsc && ' : '',


### PR DESCRIPTION
Fix: #646 

It supports `bottender dev --inspect=HOST:PORT`