### PR TITLE
fix(cli-dev): keep isTypescript false when fs.statSync throws errors

### DIFF
--- a/packages/bottender/src/cli/providers/sh/dev.ts
+++ b/packages/bottender/src/cli/providers/sh/dev.ts
@@ -26,7 +26,12 @@ const dev = async (ctx: CliContext): Promise<void> => {
 
   const { channels } = config;
 
-  const isTypescript = fs.statSync(path.resolve('tsconfig.json')).isFile;
+  let isTypescript = false;
+  try {
+    isTypescript = Boolean(fs.statSync(path.resolve('tsconfig.json')).isFile);
+  } catch {
+    // fs.statSync may throw an ENOENT error when file is not found, so keep isTypescript false
+  }
 
   // watch
   nodemon(


### PR DESCRIPTION
I let the `isTypescript` value fallback to `false` when `fs.statSync` throws any errors. This should fix the bug introduced in #654.