### PR TITLE
chore(create-bottender-app): hint users to edit the .env file

### DIFF
--- a/packages/create-bottender-app/src/index.ts
+++ b/packages/create-bottender-app/src/index.ts
@@ -389,7 +389,7 @@ const init = async (): Promise<void> => {
     print('Success!');
     print(`Created ${name} at ${root}`);
     print(
-      `Please make sure you have edited ${chalk.green(
+      `Please make sure you have edited ${chalk.green('.env')} or ${chalk.green(
         'bottender.config.js'
       )} before running the bot.`
     );


### PR DESCRIPTION
I made this change because users should edit `.env` instead of `bottender.config.js` most of the time.