### PR TITLE
fix: wording url -> URL (acronym)

### DIFF
--- a/docs/api-messenger-context.md
+++ b/docs/api-messenger-context.md
@@ -111,7 +111,7 @@ Send sounds to the user by uploading them or sharing a URL using the [Send API](
 
 Example:
 
-- Send audio using url string:
+- Send audio using URL string:
 
 ```js
 context.sendAudio('https://example.com/audio.mp3');
@@ -144,7 +144,7 @@ Send images to the user by uploading them or sharing a URL using the [Send API](
 
 Example:
 
-- Send image using url string:
+- Send image using URL string:
 
 ```js
 context.sendImage('https://example.com/vr.jpg');
@@ -177,7 +177,7 @@ Send videos to the user by uploading them or sharing a URL using the [Send API](
 
 Example:
 
-- Send video using url string:
+- Send video using URL string:
 
 ```js
 context.sendVideo('https://example.com/video.mp4');
@@ -210,7 +210,7 @@ Send files to the user by uploading them or sharing a URL using the [Send API](h
 
 Example:
 
-- Send file using url string:
+- Send file using URL string:
 
 ```js
 context.sendFile('https://example.com/receipt.pdf');

--- a/docs/channel-line-setup.md
+++ b/docs/channel-line-setup.md
@@ -78,11 +78,11 @@ When you run bottender in development mode, Bottender automatically run up a ngr
 
 ```
 App has started
-line webhook url: https://42bbf602.ngrok.io/webhooks/line
+line webhook URL: https://42bbf602.ngrok.io/webhooks/line
 server is running on 5000 port...
 ```
 
-Then, you have to manually copy your webhook url to LINE official account's settings page. Finally, you are ready to interact with your bot on LINE.
+Then, you have to manually copy your webhook URL to LINE official account's settings page. Finally, you are ready to interact with your bot on LINE.
 
 > **Note:**
 >

--- a/docs/channel-messenger-persona.md
+++ b/docs/channel-messenger-persona.md
@@ -29,7 +29,7 @@ In the following section, you can see the beginning usage of `Persona.`
 
 The basic idea behind creating a persona is sending a request to Page's `/persona` endpoint. Hence, please remember to finish relevant Facebook Page Token settings in your `bottender.config.js`.
 
-You can create a persona with the following commands. The property should include `name` and `profile picture url` for the persona.
+You can create a persona with the following commands. The property should include `name` and `profile picture URL` for the persona.
 
 #### Request
 

--- a/docs/channel-messenger-profile.md
+++ b/docs/channel-messenger-profile.md
@@ -122,7 +122,7 @@ module.exports = {
 };
 ```
 
-> **Note:** If you use any `web_url` buttons with `messengerExtensions` to `true`, you must set the domain of the url as a [whitelisted domain](channel-messenger-profile.md#setting-domain-whitelist).
+> **Note:** If you use any `web_url` buttons with `messengerExtensions` to `true`, you must set the domain of the URL as a [whitelisted domain](channel-messenger-profile.md#setting-domain-whitelist).
 
 ### Disabling User Input
 

--- a/docs/channel-slack-setup.md
+++ b/docs/channel-slack-setup.md
@@ -124,7 +124,7 @@ When you run bottender in development mode, Bottender automatically run up a ngr
 
 ```
 App has started
-slack webhook url: https://42bbf602.ngrok.io/webhooks/slack
+slack webhook URL: https://42bbf602.ngrok.io/webhooks/slack
 server is running on 5000 port...
 ```
 

--- a/docs/channel-slack-slash-command.md
+++ b/docs/channel-slack-slash-command.md
@@ -20,7 +20,7 @@ To enable this feature, you need to:
 
 - Fill in fields in the form correspondingly and save it.
   - `Command`: Your command text, must start with `/`
-  - `Request URL`: The webhook url of your slack bot.
+  - `Request URL`: The webhook URL of your slack bot.
   - `Short Description`: Description to explain what this command does.
   - `Usage Hint`: Hint text for arguments (Optional)
 

--- a/docs/channel-telegram-setup.md
+++ b/docs/channel-telegram-setup.md
@@ -87,7 +87,7 @@ When you run bottender in development mode, Bottender automatically run up a ngr
 
 ```
 App has started
-telegram webhook url: https://42bbf602.ngrok.io/webhooks/telegram
+telegram webhook URL: https://42bbf602.ngrok.io/webhooks/telegram
 server is running on 5000 port...
 ```
 

--- a/docs/channel-viber-setup.md
+++ b/docs/channel-viber-setup.md
@@ -73,7 +73,7 @@ When you run bottender in development mode, Bottender automatically run up a ngr
 
 ```
 App has started
-viber webhook url: https://42bbf602.ngrok.io/webhooks/viber
+viber webhook URL: https://42bbf602.ngrok.io/webhooks/viber
 server is running on 5000 port...
 ```
 

--- a/packages/bottender/src/cache/__tests__/RedisCacheStore.spec.ts
+++ b/packages/bottender/src/cache/__tests__/RedisCacheStore.spec.ts
@@ -46,7 +46,7 @@ describe('#constructor', () => {
     });
   });
 
-  it('can call with url', () => {
+  it('can call with URL', () => {
     const store = new RedisCacheStore('redis://:authpassword@127.0.0.1:6380/4'); // eslint-disable-line no-unused-vars
 
     expect(Redis).toBeCalledWith('redis://:authpassword@127.0.0.1:6380/4');

--- a/packages/bottender/src/cli/providers/messenger/persona.ts
+++ b/packages/bottender/src/cli/providers/messenger/persona.ts
@@ -17,14 +17,14 @@ const help = () => {
   ${chalk.dim('Commands:')}
 
     list              List all personas.
-    create            Create a new persona with name and profile picture url.
+    create            Create a new persona with name and profile picture URL.
     get               Get persona by persona ID.
     del, delete       Delete persona by persona ID.
 
   ${chalk.dim('Options:')}
 
     --name            Specify persona's name when create
-    --pic             Specify persona's profile image url when create
+    --pic             Specify persona's profile image URL when create
     --id              Specify persona's ID to get or delete
 
   ${chalk.dim('Examples:')}
@@ -70,7 +70,7 @@ export async function createPersona(ctx: CliContext): Promise<void> {
     );
     invariant(
       personaUrl,
-      '`pic` is required but not found. Use --pic <url> to specify persona profile picture url'
+      '`pic` is required but not found. Use --pic <URL> to specify persona profile picture URL'
     );
 
     const client = MessengerClient.connect({
@@ -121,7 +121,7 @@ export async function listPersona(_: CliContext): Promise<void> {
     if (personas.length !== 0) {
       print('Personas');
       const table = new Table({
-        head: ['id', 'name', 'image url'],
+        head: ['id', 'name', 'image URL'],
         colWidths: [30, 30, 30],
       });
       personas.forEach(item => {

--- a/packages/bottender/src/cli/providers/messenger/webhook.ts
+++ b/packages/bottender/src/cli/providers/messenger/webhook.ts
@@ -26,7 +26,7 @@ const help = (): void => {
 
     ${chalk.dim('Examples:')}
 
-    ${chalk.dim('-')} Set Messenger webhook url
+    ${chalk.dim('-')} Set Messenger webhook URL
 
       ${chalk.cyan('$ bottender messenger webhook set -w http://example.com')}
 
@@ -79,9 +79,9 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
     });
 
     if (!webhook) {
-      warn('We can not find the webhook callback url you provided.');
+      warn('We can not find the webhook callback URL you provided.');
       const prompt = new Confirm(
-        `Are you using ngrok (get url from ngrok server on http://127.0.0.1:${ngrokPort})?`
+        `Are you using ngrok (get URL from ngrok server on http://127.0.0.1:${ngrokPort})?`
       );
       const result = await prompt.run();
       if (result) {

--- a/packages/bottender/src/cli/providers/sh/dev.ts
+++ b/packages/bottender/src/cli/providers/sh/dev.ts
@@ -67,7 +67,7 @@ const dev = async (ctx: CliContext): Promise<void> => {
       .forEach(([channel, { path: webhookPath }]) => {
         const routePath = webhookPath || `/webhooks/${channel}`;
 
-        console.log(`${channel} webhook url: ${url}${routePath}`);
+        console.log(`${channel} webhook URL: ${url}${routePath}`);
       });
   }
 };

--- a/packages/bottender/src/cli/providers/telegram/webhook.ts
+++ b/packages/bottender/src/cli/providers/telegram/webhook.ts
@@ -70,9 +70,9 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
     });
 
     if (!webhook) {
-      warn('We can not find the webhook callback url you provided.');
+      warn('We can not find the webhook callback URL you provided.');
       const prompt = new Confirm(
-        `Are you using ngrok (get url from ngrok server on http://127.0.0.1:${ngrokPort})?`
+        `Are you using ngrok (get URL from ngrok server on http://127.0.0.1:${ngrokPort})?`
       );
       const result = await prompt.run();
       if (result) {

--- a/packages/bottender/src/cli/providers/viber/webhook.ts
+++ b/packages/bottender/src/cli/providers/viber/webhook.ts
@@ -51,10 +51,10 @@ export async function setWebhook(ctx: CliContext): Promise<void> {
     );
 
     if (!webhook) {
-      warn('We can not find the webhook callback url you provided.');
+      warn('We can not find the webhook callback URL you provided.');
 
       const prompt = new Confirm(
-        `Are you using ngrok (get url from ngrok server on http://127.0.0.1:${ngrokPort})?`
+        `Are you using ngrok (get URL from ngrok server on http://127.0.0.1:${ngrokPort})?`
       );
 
       const result = await prompt.run();

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -216,7 +216,7 @@ export default class MessengerConnector
 
   _profilePicExpired(user: { profilePic: string }): boolean {
     try {
-      // Facebook CDN returns expiration time in the key `ext` in url params like:
+      // Facebook CDN returns expiration time in the key `ext` in URL params like:
       // https://platform-lookaside.fbsbx.com/platform/profilepic/?psid=11111111111111&width=1024&ext=1543379908&hash=xxxxxxxxxxxx
       const ext = new URL(user.profilePic).searchParams.get('ext');
 

--- a/packages/bottender/src/shared/__tests__/getWebhookFromNgrok.spec.ts
+++ b/packages/bottender/src/shared/__tests__/getWebhookFromNgrok.spec.ts
@@ -81,7 +81,7 @@ it('be defined', () => {
   expect(getWebhookFromNgrok).toBeDefined();
 });
 
-it('create axios with 4040 port and return the correct url', async () => {
+it('create axios with 4040 port and return the correct URL', async () => {
   const axiosInstance = {
     get: jest.fn().mockResolvedValue(res),
   };
@@ -97,7 +97,7 @@ it('create axios with 4040 port and return the correct url', async () => {
   });
 });
 
-it('create axios with specified port and return correct url', async () => {
+it('create axios with specified port and return correct URL', async () => {
   const axiosInstance = {
     get: jest.fn().mockResolvedValue(res),
   };


### PR DESCRIPTION
The term `URL` is an acronym, so we should keep using `URL` excepting name of arguments and variables. 