### PR TITLE
fix(create-bottender-app): add dist to git ignore for TypeScript

### DIFF
--- a/packages/create-bottender-app/template-typescript/gitignore
+++ b/packages/create-bottender-app/template-typescript/gitignore
@@ -41,7 +41,7 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
+# TypeScript v1 declaration files
 typings/
 
 # Optional npm cache directory
@@ -61,3 +61,6 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# TypeScript compiled directory
+dist

--- a/packages/create-bottender-app/template/gitignore
+++ b/packages/create-bottender-app/template/gitignore
@@ -41,7 +41,7 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
+# TypeScript v1 declaration files
 typings/
 
 # Optional npm cache directory


### PR DESCRIPTION
Avoid committing the `/dist` directory into the Git.