### PR TITLE
fix(Server): fix responding with application/json when using custom servers

### DIFF
--- a/packages/bottender/src/server/Server.ts
+++ b/packages/bottender/src/server/Server.ts
@@ -149,7 +149,16 @@ class Server {
               res.setHeader(key, value as string);
             });
             res.statusCode = response.status || 200;
-            res.end(response.body || '');
+            if (
+              response.body &&
+              typeof response.body === 'object' &&
+              !Buffer.isBuffer(response.body)
+            ) {
+              res.setHeader('Content-Type', 'application/json; charset=utf-8');
+              res.end(JSON.stringify(response.body));
+            } else {
+              res.end(response.body || '');
+            }
           } else {
             res.statusCode = 200;
             res.end('');


### PR DESCRIPTION
Got the following error when provide a `{ }` object to the `res.end()` method.

```
TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer. Received an instance of Object
```

Fix it by attaching the `Content-Type: application/json; charset=utf-8` header.