### PR TITLE
fix(messenger-persistent-menu-example): use camelcase keys

### DIFF
--- a/examples/messenger-persistent-menu/bottender.config.js
+++ b/examples/messenger-persistent-menu/bottender.config.js
@@ -9,14 +9,14 @@ module.exports = {
       appSecret: process.env.MESSENGER_APP_SECRET,
       verifyToken: process.env.MESSENGER_VERIFY_TOKEN,
       profile: {
-        get_started: {
+        getStarted: {
           payload: 'GET_STARTED',
         },
-        persistent_menu: [
+        persistentMenu: [
           {
             locale: 'default',
-            composer_input_disabled: false,
-            call_to_actions: [
+            composerInputDisabled: false,
+            callToActions: [
               {
                 type: 'web_url',
                 title: 'URL 1',


### PR DESCRIPTION
Using camelcase keys is more accurate in Bottender v1.