### PR TITLE
fix(create-bottender-app): install eslint-plugin-import for --typescript

### DIFF
--- a/packages/create-bottender-app/src/index.ts
+++ b/packages/create-bottender-app/src/index.ts
@@ -246,6 +246,7 @@ const run = async (
               'typescript',
               '@typescript-eslint/parser',
               '@typescript-eslint/eslint-plugin',
+              'eslint-plugin-import',
             ]
           : []),
       ],

--- a/packages/create-bottender-app/template-typescript/.eslintrc.js
+++ b/packages/create-bottender-app/template-typescript/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
       },
     ],
   },
-  plugins: ['prettier', '@typescript-eslint'],
+  plugins: ['import', 'prettier', '@typescript-eslint'],
   overrides: [
     {
       files: ['**/*.test.ts'],


### PR DESCRIPTION
We used the `import/no-unresolved` rule in the TypeScript template, so `eslint-plugin-import` is needed.

https://github.com/Yoctol/bottender/blob/2c64f3c9bed863f51f29c293cb0915a37a590d3b/packages/create-bottender-app/template-typescript/index.js#L1