### PR TITLE
fix: bottender/router in TypeScript

### DIFF
--- a/packages/bottender/router.d.ts
+++ b/packages/bottender/router.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/router';


### PR DESCRIPTION
We need those two files:

```
<root>/router.js
<root>/router.d.ts
```

To make sure that we can safely import the `bottender/router` module:

```
import { router } from 'bottender/router';
```

Or it causes the following error:

```
Try `npm install @types/bottender` if it exists or add a new declaration (.d.ts) file containing `declare module 'bottender/router';`
```
