### PR TITLE
docs(telegram-setup): fix a misplaced command and some grammar mistakes

### DIFF
--- a/docs/channel-telegram-setup.md
+++ b/docs/channel-telegram-setup.md
@@ -83,7 +83,7 @@ For more information, please refer to Telegram's official doc, [BotFather](https
 
 Before setting the webhook, please make sure you have set your access token correctly in `.env`.
 
-By the following command, Bottender runs a bot server by ngrok, which makes your local bot server accessible from the Internet.
+By the following command, Bottender runs a bot server by ngrok, which makes your local bot server accessible from the Internet:
 
 ```sh
 # in development
@@ -98,7 +98,7 @@ telegram webhook URL: https://42bbf602.ngrok.io/webhooks/telegram
 server is running on 5000 port...
 ```
 
-Then, you can open a new tab in the terminal and finish the webhook setting by the below command.
+Then, you can open a new tab in the terminal and finish the webhook setting by the below command:
 
 ```sh
 npx bottender telegram webhook set
@@ -108,13 +108,13 @@ Finally, press `Y` to allow Bottender set `ngrok` temporary URL as the webhook. 
 
 ### Set Up Webhook for Production
 
-Before setting the webhook, please make sure you set your access token correctly as the environment variable.
+Before setting the webhook, please make sure you have set your access token correctly as the environment variable.
 
-Then, you can run Bottender on your hosting by the following command.
+Then, you can run Bottender on your hosting by the following command:
 
 ```sh
-# in development
-npm run dev
+# in production
+npm start
 ```
 
 By the following command, you can finish the Telegram webhook setting. (If you deployed your bot with the default webhook setting, you webhook for Telegram bot supposed to be `https://example.com/webhooks/telegram` )

--- a/website/versioned_docs/version-1.0.5/channel-telegram-setup.md
+++ b/website/versioned_docs/version-1.0.5/channel-telegram-setup.md
@@ -77,7 +77,7 @@ TELEGRAM_ACCESS_TOKEN=
 
 Before setting the webhook, please make sure you have set your access token correctly in `.env`.
 
-By the following command, Bottender runs a bot server by ngrok, which makes your local bot server accessible from the Internet.
+By the following command, Bottender runs a bot server by ngrok, which makes your local bot server accessible from the Internet:
 
 ```sh
 # in development
@@ -92,7 +92,7 @@ telegram webhook url: https://42bbf602.ngrok.io/webhooks/telegram
 server is running on 5000 port...
 ```
 
-Then, you can open a new tab in the terminal and finish the webhook setting by the below command.
+Then, you can open a new tab in the terminal and finish the webhook setting by the below command:
 
 ```sh
 npx bottender telegram webhook set
@@ -102,13 +102,13 @@ Finally, press `Y` to allow Bottender set `ngrok` temporary URL as the webhook. 
 
 #### Set Up Webhook for Production
 
-Before setting the webhook, please make sure you set your access token correctly as the environment variable.
+Before setting the webhook, please make sure you have set your access token correctly as the environment variable.
 
-Then, you can run Bottender on your hosting by the following command.
+Then, you can run Bottender on your hosting by the following command:
 
 ```sh
-# in development
-npm run dev
+# in production
+npm start
 ```
 
 By the following command, you can finish the Telegram webhook setting. (If you deployed your bot with the default webhook setting, you webhook for Telegram bot supposed to be `https://example.com/webhooks/telegram` )

--- a/website/versioned_docs/version-1.3.1/channel-telegram-setup.md
+++ b/website/versioned_docs/version-1.3.1/channel-telegram-setup.md
@@ -84,7 +84,7 @@ For more information, please refer to Telegram's official doc, [BotFather](https
 
 Before setting the webhook, please make sure you have set your access token correctly in `.env`.
 
-By the following command, Bottender runs a bot server by ngrok, which makes your local bot server accessible from the Internet.
+By the following command, Bottender runs a bot server by ngrok, which makes your local bot server accessible from the Internet:
 
 ```sh
 # in development
@@ -99,7 +99,7 @@ telegram webhook URL: https://42bbf602.ngrok.io/webhooks/telegram
 server is running on 5000 port...
 ```
 
-Then, you can open a new tab in the terminal and finish the webhook setting by the below command.
+Then, you can open a new tab in the terminal and finish the webhook setting by the below command:
 
 ```sh
 npx bottender telegram webhook set
@@ -109,13 +109,13 @@ Finally, press `Y` to allow Bottender set `ngrok` temporary URL as the webhook. 
 
 ### Set Up Webhook for Production
 
-Before setting the webhook, please make sure you set your access token correctly as the environment variable.
+Before setting the webhook, please make sure you have set your access token correctly as the environment variable.
 
-Then, you can run Bottender on your hosting by the following command.
+Then, you can run Bottender on your hosting by the following command:
 
 ```sh
-# in development
-npm run dev
+# in production
+npm start
 ```
 
 By the following command, you can finish the Telegram webhook setting. (If you deployed your bot with the default webhook setting, you webhook for Telegram bot supposed to be `https://example.com/webhooks/telegram` )


### PR DESCRIPTION
In production, we should use `npm start` instead of `npm run dev`.