### PR TITLE
feat(messenger): support reaction event and routing

### DIFF
--- a/docs/channel-messenger-routing.md
+++ b/docs/channel-messenger-routing.md
@@ -24,6 +24,9 @@ function App() {
     messenger.optin(HandleOptin),
     messenger.policyEnforcement(HandlePolicyEnforcement),
     messenger.postback(HandlePostback),
+    messenger.reaction.react(HandleReactionReact),
+    messenger.reaction.unreact(HandleReactionUnreact),
+    messenger.reaction(HandleReaction),
     messenger.read(HandleRead),
     messenger.referral(HandleReferral),
     messenger.standby(HandleStandby),
@@ -46,6 +49,9 @@ async function HandleAppRoles(context) {}
 async function HandleOptin(context) {}
 async function HandlePolicyEnforcement(context) {}
 async function HandlePostback(context) {}
+async function HandleReactionReact(context) {}
+async function HandleReactionUnreact(context) {}
+async function HandleReaction(context) {}
 async function HandleRead(context) {}
 async function HandleReferral(context) {}
 async function HandleStandby(context) {}
@@ -70,6 +76,9 @@ All available routes in `messenger` that recognize different kind of events:
 - `messenger.policyEnforcement` - triggers the action when receiving Messenger `policy_enforcement` events.
 - `messenger.postback` - triggers the action when receiving Messenger `postback` events.
 - `messenger.preCheckout` - triggers the action when receiving Messenger `pre_checkout` events.
+- `messenger.reaction.react` - triggers the action when receiving Messenger `reaction` events with action `react`.
+- `messenger.reaction.unreact` - triggers the action when receiving Messenger `reaction` events with action `unreact`.
+- `messenger.reaction` - triggers the action when receiving Messenger `reaction` events.
 - `messenger.read` - triggers the action when receiving Messenger `read` events.
 - `messenger.referral` - triggers the action when receiving Messenger `referral` events.
 - `messenger.standby` - triggers the action when receiving Messenger `standby` events.

--- a/packages/bottender/src/messenger/MessengerEvent.ts
+++ b/packages/bottender/src/messenger/MessengerEvent.ts
@@ -175,6 +175,21 @@ export type AccountLinking =
   | { status: 'linked'; authorizationCode: string }
   | { status: 'unlinked' };
 
+export type Reaction = {
+  reaction:
+    | 'smile'
+    | 'angry'
+    | 'sad'
+    | 'wow'
+    | 'love'
+    | 'like'
+    | 'dislike'
+    | 'other';
+  emoji: string;
+  action: 'react' | 'unreact';
+  mid: string;
+};
+
 export type MessengerRawEvent = {
   sender?: Sender;
   recipient?: Recipient;
@@ -196,6 +211,7 @@ export type MessengerRawEvent = {
   referral?: Referral;
   brandedCamera?: BrandedCamera;
   accountLinking?: AccountLinking;
+  reaction?: Reaction;
 };
 
 type MessengerEventOptions = {
@@ -863,5 +879,26 @@ export default class MessengerEvent implements Event<MessengerRawEvent> {
       return null;
     }
     return (this._rawEvent as any).accountLinking;
+  }
+
+  /**
+   * Determine if the event is a reaction event.
+   *
+   */
+  get isReaction(): boolean {
+    return (
+      !!this._rawEvent.reaction && typeof this._rawEvent.reaction === 'object'
+    );
+  }
+
+  /**
+   * The reaction object from Messenger event.
+   *
+   */
+  get reaction(): Reaction | null {
+    if (!this.isReaction) {
+      return null;
+    }
+    return (this._rawEvent as any).reaction;
   }
 }

--- a/packages/bottender/src/messenger/__tests__/MessengerEvent.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/MessengerEvent.spec.ts
@@ -610,6 +610,38 @@ const accountLinkingUnlinked = {
   },
 };
 
+const reactionReact = {
+  sender: {
+    id: '1476077422222289',
+  },
+  recipient: {
+    id: '707356222221168',
+  },
+  timestamp: 1469111400000,
+  reaction: {
+    reaction: 'smile',
+    emoji: '\u{2764}\u{FE0F}',
+    action: 'react',
+    mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
+  },
+};
+
+const reactionUnreact = {
+  sender: {
+    id: '1476077422222289',
+  },
+  recipient: {
+    id: '707356222221168',
+  },
+  timestamp: 1469111400000,
+  reaction: {
+    reaction: 'smile',
+    emoji: '\u{2764}\u{FE0F}',
+    action: 'unreact',
+    mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
+  },
+};
+
 it('#rawEvent', () => {
   expect(new MessengerEvent(textMessage).rawEvent).toEqual(textMessage);
   expect(new MessengerEvent(imageMessage).rawEvent).toEqual(imageMessage);
@@ -1453,5 +1485,29 @@ it('#accountLinking', () => {
   });
   expect(new MessengerEvent(accountLinkingUnlinked).accountLinking).toEqual({
     status: 'unlinked',
+  });
+});
+
+it('#isReaction', () => {
+  expect(new MessengerEvent(textMessage).isReaction).toEqual(false);
+  expect(new MessengerEvent(postback).isReaction).toEqual(false);
+  expect(new MessengerEvent(reactionReact).isReaction).toEqual(true);
+  expect(new MessengerEvent(reactionUnreact).isReaction).toEqual(true);
+});
+
+it('#reaction', () => {
+  expect(new MessengerEvent(textMessage).reaction).toEqual(null);
+  expect(new MessengerEvent(postback).reaction).toEqual(null);
+  expect(new MessengerEvent(reactionReact).reaction).toEqual({
+    reaction: 'smile',
+    emoji: '\u{2764}\u{FE0F}',
+    action: 'react',
+    mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
+  });
+  expect(new MessengerEvent(reactionUnreact).reaction).toEqual({
+    reaction: 'smile',
+    emoji: '\u{2764}\u{FE0F}',
+    action: 'unreact',
+    mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
   });
 });

--- a/packages/bottender/src/messenger/__tests__/routes.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/routes.spec.ts
@@ -322,6 +322,38 @@ const messengerEventStandby = new MessengerEvent(
   { isStandby: true }
 );
 
+const messengerEventReactionReact = new MessengerEvent({
+  sender: {
+    id: '1476077422222289',
+  },
+  recipient: {
+    id: '707356222221168',
+  },
+  timestamp: 1469111400000,
+  reaction: {
+    reaction: 'smile',
+    emoji: '\u{2764}\u{FE0F}',
+    action: 'react',
+    mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
+  },
+});
+
+const messengerEventReactionUnreact = new MessengerEvent({
+  sender: {
+    id: '1476077422222289',
+  },
+  recipient: {
+    id: '707356222221168',
+  },
+  timestamp: 1469111400000,
+  reaction: {
+    reaction: 'smile',
+    emoji: '\u{2764}\u{FE0F}',
+    action: 'unreact',
+    mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
+  },
+});
+
 async function Action(context) {
   await context.sendText('hello');
 }
@@ -717,6 +749,54 @@ describe('#messenger', () => {
       await expectRouteNotMatchMessengerEvent({
         route: messenger.standby(Action),
         event: messengerEventTextMessage,
+      });
+    });
+  });
+
+  describe('#messenger.reaction', () => {
+    it('should call action when it receives a messenger reaction event', async () => {
+      await expectRouteMatchMessengerEvent({
+        route: messenger.reaction(Action),
+        event: messengerEventReactionReact,
+      });
+    });
+
+    it('should not call action when it receives a non-reaction event', async () => {
+      await expectRouteNotMatchMessengerEvent({
+        route: messenger.reaction(Action),
+        event: messengerEventTextMessage,
+      });
+    });
+
+    describe('#messenger.reaction.react', () => {
+      it('should call action when it receives a messenger reaction.react event', async () => {
+        await expectRouteMatchMessengerEvent({
+          route: messenger.reaction.react(Action),
+          event: messengerEventReactionReact,
+        });
+      });
+
+      it('should not call action when it receives a non-reaction.react event', async () => {
+        await expectRouteNotMatchMessengerEvent({
+          route: messenger.reaction.react(Action),
+          event: messengerEventReactionUnreact,
+        });
+      });
+    });
+
+    describe('#messenger.reaction.unreact', () => {
+      it('should call action when it receives a messenger reaction.unreact event', async () => {
+        await expectRouteMatchMessengerEvent({
+          route: messenger.reaction.unreact(Action),
+          event: messengerEventReactionUnreact,
+        });
+      });
+
+      it('should not call action when it receives a non-reaction.unreact event', async () => {
+        await expectRouteNotMatchMessengerEvent({
+          route: messenger.reaction.unreact(Action),
+          event: messengerEventReactionReact,
+        });
       });
     });
   });

--- a/packages/bottender/src/messenger/routes.ts
+++ b/packages/bottender/src/messenger/routes.ts
@@ -31,6 +31,10 @@ type Messenger = Route & {
   read: Route;
   referral: Route;
   standby: Route;
+  reaction: Route & {
+    react: Route;
+    unreact: Route;
+  };
 };
 
 const messenger: Messenger = <C extends Context<any, any>>(
@@ -248,5 +252,39 @@ function standby<C extends Context<any, any>>(action: Action<C, any>) {
 }
 
 messenger.standby = standby;
+
+function reaction<C extends Context<any, any>>(action: Action<C, any>) {
+  return route(
+    (context: C) =>
+      context.platform === 'messenger' && context.event.isReaction,
+    action
+  );
+}
+
+messenger.reaction = reaction;
+
+function reactionReact<C extends Context<any, any>>(action: Action<C, any>) {
+  return route(
+    (context: C) =>
+      context.platform === 'messenger' &&
+      context.event.isReaction &&
+      context.event.reaction.action === 'react',
+    action
+  );
+}
+
+reaction.react = reactionReact;
+
+function reactionUnreact<C extends Context<any, any>>(action: Action<C, any>) {
+  return route(
+    (context: C) =>
+      context.platform === 'messenger' &&
+      context.event.isReaction &&
+      context.event.reaction.action === 'unreact',
+    action
+  );
+}
+
+reaction.unreact = reactionUnreact;
 
 export default messenger;


### PR DESCRIPTION
https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/message-reactions/

Support `event.isReaction` & `event.react`:

```js
function App(context) {
  if (context.event.isReaction) {
    console.log(context.event.reaction);
    // {
    //   reaction: 'smile',
    //   emoji: '\u{2764}\u{FE0F}',
    //   action: 'react',
    //   mid: 'mid.$cAAE1UUyiiwthh0NPrVbVf4HFNDGl',
    //  }
  }
}
```

Support detect events in routers:

```js
const { router, messenger } = require('bottender/router');

function App() {
  return router([
    messenger.reaction.react(HandleReactionReact),
    messenger.reaction.unreact(HandleReactionUnreact),
    messenger.reaction(HandleReaction),
  ]);
}

async function HandleReactionReact(context) {}
async function HandleReactionUnreact(context) {}
async function HandleReaction(context) {}
```