### PR TITLE
feat(route): provides namespace.any for better readability

### DIFF
--- a/docs/channel-line-routing.md
+++ b/docs/channel-line-routing.md
@@ -25,7 +25,7 @@ function App() {
     line.things.link(HandleThingsLink),
     line.things.unlink(HandleThingsUnlink),
     line.things.scenarioResult(HandleThingsScenarioResult),
-    line(HandleLine),
+    line.any(HandleLine),
   ]);
 }
 
@@ -50,7 +50,7 @@ async function HandleLine(context) {}
 
 All available routes in `line` that recognize different kind of events:
 
-- `line` - triggers the action when receiving any LINE events.
+- `line.any` - triggers the action when receiving any LINE events.
 - `line.message` - triggers the action when receiving LINE `message` events.
 - `line.follow` - triggers the action when receiving LINE `follow` events.
 - `line.unfollow` - triggers the action when receiving LINE `unfollow` events.

--- a/docs/channel-messenger-routing.md
+++ b/docs/channel-messenger-routing.md
@@ -27,7 +27,7 @@ function App() {
     messenger.read(HandleRead),
     messenger.referral(HandleReferral),
     messenger.standby(HandleStandby),
-    messenger(HandleMessenger),
+    messenger.any(HandleMessenger),
   ]);
 }
 
@@ -54,7 +54,7 @@ async function HandleMessenger(context) {}
 
 All available routes in `messenger` that recognize different kind of events:
 
-- `messenger` - triggers the action when receiving any Messenger events.
+- `messenger.any` - triggers the action when receiving any Messenger events.
 - `messenger.message` - triggers the action when receiving Messenger `message` events.
 - `messenger.accountLinking.linked` - triggers the action when receiving Messenger `account_linking` events with status `linked`.
 - `messenger.accountLinking.unlinked` - triggers the action when receiving Messenger `account_linking` events with status `unlinked`.

--- a/docs/channel-slack-routing.md
+++ b/docs/channel-slack-routing.md
@@ -13,7 +13,7 @@ function App() {
     slack.message(HandleMessage),
     slack.event('pin_added', HandlePinAdded),
     slack.event('star_added', HandleStarAdded),
-    slack(HandleSlack),
+    slack.any(HandleSlack),
   ]);
 }
 
@@ -26,6 +26,6 @@ async function HandleSlack(context) {}
 
 All available routes in `slack` that recognize different kind of events:
 
-- `slack` - triggers the action when receiving any Slack events.
+- `slack.any` - triggers the action when receiving any Slack events.
 - `slack.message` - triggers the action when receiving Slack message events.
 - `slack.event` - triggers the action when receiving particular Slack events. See all event types in [Slack docs](https://api.slack.com/events).

--- a/docs/channel-telegram-routing.md
+++ b/docs/channel-telegram-routing.md
@@ -20,7 +20,7 @@ function App() {
     telegram.shippingQuery(HandleShippingQuery),
     telegram.preCheckoutQuery(HandlePreCheckoutQuery),
     telegram.poll(HandlePoll),
-    telegram(HandleTelegram),
+    telegram.any(HandleTelegram),
   ]);
 }
 
@@ -40,7 +40,7 @@ async function HandleTelegram(context) {}
 
 All available routes in `telegram` that recognize different kind of events:
 
-- `telegram` - triggers the action when receiving any Telegram events.
+- `telegram.any` - triggers the action when receiving any Telegram events.
 - `telegram.message` - triggers the action when receiving Telegram `message` events.
 - `telegram.editedMessage` - triggers the action when receiving Telegram `editedMessage` events.
 - `telegram.channelPost` - triggers the action when receiving Telegram `channelPost` events.

--- a/docs/channel-viber-routing.md
+++ b/docs/channel-viber-routing.md
@@ -17,7 +17,7 @@ function App() {
     viber.delivered(HandleDelivered),
     viber.seen(HandleSeen),
     viber.failed(HandleFailed),
-    viber(HandleViber),
+    viber.any(HandleViber),
   ]);
 }
 
@@ -34,7 +34,7 @@ async function HandleViber(context) {}
 
 All available routes in `viber` that recognize different kind of events:
 
-- `viber` - triggers the action when receiving any Viber events.
+- `viber.any` - triggers the action when receiving any Viber events.
 - `viber.message` - triggers the action when receiving Viber `message` events.
 - `viber.subscribed` - triggers the action when receiving Viber `subscribed` events.
 - `viber.unsubscribed` - triggers the action when receiving Viber `unsubscribed` events.

--- a/docs/channel-whatsapp-routing.md
+++ b/docs/channel-whatsapp-routing.md
@@ -16,7 +16,7 @@ function App() {
     whatsapp.sent(HandleSent),
     whatsapp.delivered(HandleDelivered),
     whatsapp.read(HandleRead),
-    whatsapp(HandleWhatsapp),
+    whatsapp.any(HandleWhatsapp),
   ]);
 }
 
@@ -32,7 +32,7 @@ async function HandleWhatsapp(context) {}
 
 All available routes in `whatsapp` that recognize different kind of events:
 
-- `whatsapp` - triggers the action when receiving any WhatsApp events.
+- `whatsapp.any` - triggers the action when receiving any WhatsApp events.
 - `whatsapp.message` - triggers the action when receiving WhatsApp `received` events. Alias: `whatsapp.received`.
 - `whatsapp.media` - triggers the action when receiving WhatsApp `received` events includes media.
 - `whatsapp.received` - triggers the action when receiving WhatsApp `received` events.

--- a/packages/bottender/src/line/__tests__/routes.spec.ts
+++ b/packages/bottender/src/line/__tests__/routes.spec.ts
@@ -323,6 +323,25 @@ describe('#line', () => {
     });
   });
 
+  describe('#line.any', () => {
+    it('should call action when it receives a line event', async () => {
+      await expectRouteMatchLineEvent({
+        route: line.any(Action),
+        event: lineEventTextMessage,
+      });
+    });
+
+    it('should not call action when it receives a non-line event', async () => {
+      await expectRouteNotMatchContext({
+        route: line.any(Action),
+        context: new TestContext({
+          client: {} as any,
+          event: {},
+        }),
+      });
+    });
+  });
+
   describe('#line.message', () => {
     it('should call action when it receives a line message event', async () => {
       await expectRouteMatchLineEvent({

--- a/packages/bottender/src/line/routes.ts
+++ b/packages/bottender/src/line/routes.ts
@@ -10,6 +10,7 @@ type Route = <C extends Context<any, any>>(
 };
 
 type Line = Route & {
+  any: Route;
   message: Route;
   follow: Route;
   unfollow: Route;
@@ -34,6 +35,8 @@ type Line = Route & {
 const line: Line = <C extends Context<any, any>>(action: Action<C, any>) => {
   return route(context => context.platform === 'line', action);
 };
+
+line.any = line;
 
 function message<C extends Context<any, any>>(action: Action<C, any>) {
   return route(

--- a/packages/bottender/src/messenger/__tests__/routes.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/routes.spec.ts
@@ -401,6 +401,25 @@ describe('#messenger', () => {
     });
   });
 
+  describe('#messenger.any', () => {
+    it('should call action when it receives a messenger event', async () => {
+      await expectRouteMatchMessengerEvent({
+        route: messenger.any(Action),
+        event: messengerEventTextMessage,
+      });
+    });
+
+    it('should not call action when it receives a non-messenger event', async () => {
+      await expectRouteNotMatchContext({
+        route: messenger.any(Action),
+        context: new TestContext({
+          client: {} as any,
+          event: {},
+        }),
+      });
+    });
+  });
+
   describe('#messenger.message', () => {
     it('should call action when it receives a messenger message event', async () => {
       await expectRouteMatchMessengerEvent({

--- a/packages/bottender/src/messenger/routes.ts
+++ b/packages/bottender/src/messenger/routes.ts
@@ -10,6 +10,7 @@ type Route = <C extends Context<any, any>>(
 };
 
 type Messenger = Route & {
+  any: Route;
   message: Route;
   accountLinking: Route & {
     linked: Route;
@@ -38,6 +39,8 @@ const messenger: Messenger = <C extends Context<any, any>>(
 ) => {
   return route(context => context.platform === 'messenger', action);
 };
+
+messenger.any = messenger;
 
 function message<C extends Context<any, any>>(action: Action<C, any>) {
   return route(

--- a/packages/bottender/src/slack/__tests__/routes.spec.ts
+++ b/packages/bottender/src/slack/__tests__/routes.spec.ts
@@ -116,6 +116,25 @@ describe('#slack', () => {
     });
   });
 
+  describe('#slack.any', () => {
+    it('should call action when it receives a slack event', async () => {
+      await expectRouteMatchSlackEvent({
+        route: slack.any(Action),
+        event: slackEventTextMessage,
+      });
+    });
+
+    it('should not call action when it receives a non-slack event', async () => {
+      await expectRouteNotMatchContext({
+        route: slack.any(Action),
+        context: new TestContext({
+          client: {} as any,
+          event: {},
+        }),
+      });
+    });
+  });
+
   describe('#slack.message', () => {
     it('should call action when it receives a slack message event', async () => {
       await expectRouteMatchSlackEvent({

--- a/packages/bottender/src/slack/routes.ts
+++ b/packages/bottender/src/slack/routes.ts
@@ -12,6 +12,7 @@ type Route = <C extends Context<any, any>>(
 };
 
 type Slack = Route & {
+  any: Route;
   message: Route;
   event: <C extends Context<any, any>>(
     eventType: EventTypes,
@@ -32,6 +33,8 @@ type Slack = Route & {
 const slack: Slack = <C extends Context<any, any>>(action: Action<C, any>) => {
   return route((context: C) => context.platform === 'slack', action);
 };
+
+slack.any = slack;
 
 function message<C extends Context<any, any>>(action: Action<C, any>) {
   return route(

--- a/packages/bottender/src/telegram/__tests__/routes.spec.ts
+++ b/packages/bottender/src/telegram/__tests__/routes.spec.ts
@@ -273,6 +273,25 @@ describe('#telegram', () => {
     });
   });
 
+  describe('#telegram.any', () => {
+    it('should call action when it receives a telegram event', async () => {
+      await expectRouteMatchTelegramEvent({
+        route: telegram.any(Action),
+        event: telegramEventTextMessage,
+      });
+    });
+
+    it('should not call action when it receives a non-telegram event', async () => {
+      await expectRouteNotMatchContext({
+        route: telegram.any(Action),
+        context: new TestContext({
+          client: {} as any,
+          event: {},
+        }),
+      });
+    });
+  });
+
   describe('#telegram.message', () => {
     it('should call action when it receives a telegram message event', async () => {
       await expectRouteMatchTelegramEvent({

--- a/packages/bottender/src/telegram/routes.ts
+++ b/packages/bottender/src/telegram/routes.ts
@@ -10,6 +10,7 @@ type Route = <C extends Context<any, any>>(
 };
 
 type Telegram = Route & {
+  any: Route;
   message: Route;
   editedMessage: Route;
   channelPost: Route;
@@ -27,6 +28,8 @@ const telegram: Telegram = <C extends Context<any, any>>(
 ) => {
   return route(context => context.platform === 'telegram', action);
 };
+
+telegram.any = telegram;
 
 function message<C extends Context<any, any>>(action: Action<C, any>) {
   return route(

--- a/packages/bottender/src/viber/__tests__/routes.spec.ts
+++ b/packages/bottender/src/viber/__tests__/routes.spec.ts
@@ -163,6 +163,25 @@ describe('#viber', () => {
     });
   });
 
+  describe('#viber.any', () => {
+    it('should call action when it receives a viber event', async () => {
+      await expectRouteMatchViberEvent({
+        route: viber.any(Action),
+        event: viberEventTextMessage,
+      });
+    });
+
+    it('should not call action when it receives a non-viber event', async () => {
+      await expectRouteNotMatchContext({
+        route: viber.any(Action),
+        context: new TestContext({
+          client: {} as any,
+          event: {},
+        }),
+      });
+    });
+  });
+
   describe('#viber.message', () => {
     it('should call action when it receives a viber message event', async () => {
       await expectRouteMatchViberEvent({

--- a/packages/bottender/src/viber/routes.ts
+++ b/packages/bottender/src/viber/routes.ts
@@ -10,6 +10,7 @@ type Route = <C extends Context<any, any>>(
 };
 
 type Viber = Route & {
+  any: Route;
   message: Route;
   subscribed: Route;
   unsubscribed: Route;
@@ -22,6 +23,8 @@ type Viber = Route & {
 const viber: Viber = <C extends Context<any, any>>(action: Action<C, any>) => {
   return route(context => context.platform === 'viber', action);
 };
+
+viber.any = viber;
 
 function message<C extends Context<any, any>>(action: Action<C, any>) {
   return route(

--- a/packages/bottender/src/whatsapp/__tests__/routes.spec.ts
+++ b/packages/bottender/src/whatsapp/__tests__/routes.spec.ts
@@ -160,6 +160,25 @@ describe('#whatsapp', () => {
     });
   });
 
+  describe('#whatsapp.any', () => {
+    it('should call action when it receives a whatsapp event', async () => {
+      await expectRouteMatchWhatsappEvent({
+        route: whatsapp.any(Action),
+        event: whatsappEventTextMessageReceived,
+      });
+    });
+
+    it('should not call action when it receives a non-whatsapp event', async () => {
+      await expectRouteNotMatchContext({
+        route: whatsapp.any(Action),
+        context: new TestContext({
+          client: {} as any,
+          event: {},
+        }),
+      });
+    });
+  });
+
   describe('#whatsapp.message', () => {
     it('should call action when it receives a whatsapp message event', async () => {
       await expectRouteMatchWhatsappEvent({

--- a/packages/bottender/src/whatsapp/routes.ts
+++ b/packages/bottender/src/whatsapp/routes.ts
@@ -10,6 +10,7 @@ type Route = <C extends Context<any, any>>(
 };
 
 type Whatsapp = Route & {
+  any: Route;
   message: Route;
   media: Route;
   received: Route;
@@ -23,6 +24,8 @@ const whatsapp: Whatsapp = <C extends Context<any, any>>(
 ) => {
   return route(context => context.platform === 'whatsapp', action);
 };
+
+whatsapp.any = whatsapp;
 
 function message<C extends Context<any, any>>(action: Action<C, any>) {
   return route(


### PR DESCRIPTION
**After:** (use `any` as event type)

```js
function App() {
  return router([	
    messenger.any(HandleMessenger),
    line.any(HandleLine),
    slack.any(HandleSlack),
    telegram.any(HandleTelegram),
    viber.any(HandleViber),
    whatsapp.any(HandleWhatsapp),
  ]);
}
```

**Before:**

```js
function App() {
  return router([	
    messenger(HandleMessenger),
    line(HandleLine),
    slack(HandleSlack),
    telegram(HandleTelegram),
    viber(HandleViber),
    whatsapp(HandleWhatsapp),
  ]);
}
```