### PR TITLE
fix(routes): add context constraint to routes

### DIFF
--- a/packages/bottender/src/line/routes.ts
+++ b/packages/bottender/src/line/routes.ts
@@ -2,11 +2,13 @@ import Context from '../context/Context';
 import { Action } from '../types';
 import { RoutePredicate, route } from '../router';
 
+import LineContext from './LineContext';
+
 type Route = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<LineContext, any>
 ) => {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<LineContext, any>;
 };
 
 type Line = Route & {
@@ -32,13 +34,17 @@ type Line = Route & {
   };
 };
 
-const line: Line = <C extends Context<any, any>>(action: Action<C, any>) => {
-  return route(context => context.platform === 'line', action);
+const line: Line = <C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) => {
+  return route((context: C) => context.platform === 'line', action);
 };
 
 line.any = line;
 
-function message<C extends Context<any, any>>(action: Action<C, any>) {
+function message<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isMessage,
     action
@@ -47,7 +53,7 @@ function message<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.message = message;
 
-function follow<C extends Context<any, any>>(action: Action<C, any>) {
+function follow<C extends Context<any, any>>(action: Action<LineContext, any>) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isFollow,
     action
@@ -56,7 +62,9 @@ function follow<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.follow = follow;
 
-function unfollow<C extends Context<any, any>>(action: Action<C, any>) {
+function unfollow<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isUnfollow,
     action
@@ -65,7 +73,7 @@ function unfollow<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.unfollow = unfollow;
 
-function join<C extends Context<any, any>>(action: Action<C, any>) {
+function join<C extends Context<any, any>>(action: Action<LineContext, any>) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isJoin,
     action
@@ -74,7 +82,7 @@ function join<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.join = join;
 
-function leave<C extends Context<any, any>>(action: Action<C, any>) {
+function leave<C extends Context<any, any>>(action: Action<LineContext, any>) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isLeave,
     action
@@ -83,7 +91,9 @@ function leave<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.leave = leave;
 
-function memberJoined<C extends Context<any, any>>(action: Action<C, any>) {
+function memberJoined<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isMemberJoined,
     action
@@ -92,7 +102,9 @@ function memberJoined<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.memberJoined = memberJoined;
 
-function memberLeft<C extends Context<any, any>>(action: Action<C, any>) {
+function memberLeft<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isMemberLeft,
     action
@@ -101,7 +113,9 @@ function memberLeft<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.memberLeft = memberLeft;
 
-function postback<C extends Context<any, any>>(action: Action<C, any>) {
+function postback<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isPostback,
     action
@@ -110,7 +124,7 @@ function postback<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.postback = postback;
 
-function beacon<C extends Context<any, any>>(action: Action<C, any>) {
+function beacon<C extends Context<any, any>>(action: Action<LineContext, any>) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isBeacon,
     action
@@ -119,7 +133,9 @@ function beacon<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.beacon = beacon;
 
-function beaconEnter<C extends Context<any, any>>(action: Action<C, any>) {
+function beaconEnter<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'line' &&
@@ -131,7 +147,9 @@ function beaconEnter<C extends Context<any, any>>(action: Action<C, any>) {
 
 beacon.enter = beaconEnter;
 
-function beaconBanner<C extends Context<any, any>>(action: Action<C, any>) {
+function beaconBanner<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'line' &&
@@ -143,7 +161,9 @@ function beaconBanner<C extends Context<any, any>>(action: Action<C, any>) {
 
 beacon.banner = beaconBanner;
 
-function beaconStay<C extends Context<any, any>>(action: Action<C, any>) {
+function beaconStay<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'line' &&
@@ -155,7 +175,9 @@ function beaconStay<C extends Context<any, any>>(action: Action<C, any>) {
 
 beacon.stay = beaconStay;
 
-function accountLink<C extends Context<any, any>>(action: Action<C, any>) {
+function accountLink<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isAccountLink,
     action
@@ -164,7 +186,7 @@ function accountLink<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.accountLink = accountLink;
 
-function things<C extends Context<any, any>>(action: Action<C, any>) {
+function things<C extends Context<any, any>>(action: Action<LineContext, any>) {
   return route(
     (context: C) => context.platform === 'line' && context.event.isThings,
     action
@@ -173,7 +195,9 @@ function things<C extends Context<any, any>>(action: Action<C, any>) {
 
 line.things = things;
 
-function thingsLink<C extends Context<any, any>>(action: Action<C, any>) {
+function thingsLink<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'line' &&
@@ -185,7 +209,9 @@ function thingsLink<C extends Context<any, any>>(action: Action<C, any>) {
 
 things.link = thingsLink;
 
-function thingsUnlink<C extends Context<any, any>>(action: Action<C, any>) {
+function thingsUnlink<C extends Context<any, any>>(
+  action: Action<LineContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'line' &&
@@ -198,7 +224,7 @@ function thingsUnlink<C extends Context<any, any>>(action: Action<C, any>) {
 things.unlink = thingsUnlink;
 
 function thingsScenarioResult<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<LineContext, any>
 ) {
   return route(
     (context: C) =>

--- a/packages/bottender/src/messenger/routes.ts
+++ b/packages/bottender/src/messenger/routes.ts
@@ -2,11 +2,13 @@ import Context from '../context/Context';
 import { Action } from '../types';
 import { RoutePredicate, route } from '../router';
 
+import MessengerContext from './MessengerContext';
+
 type Route = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) => {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<MessengerContext, any>;
 };
 
 type Messenger = Route & {
@@ -39,14 +41,16 @@ type Messenger = Route & {
 };
 
 const messenger: Messenger = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) => {
-  return route(context => context.platform === 'messenger', action);
+  return route((context: C) => context.platform === 'messenger', action);
 };
 
 messenger.any = messenger;
 
-function message<C extends Context<any, any>>(action: Action<C, any>) {
+function message<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) => context.platform === 'messenger' && context.event.isMessage,
     action
@@ -55,7 +59,9 @@ function message<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.message = message;
 
-function accountLinking<C extends Context<any, any>>(action: Action<C, any>) {
+function accountLinking<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isAccountLinking,
@@ -66,7 +72,7 @@ function accountLinking<C extends Context<any, any>>(action: Action<C, any>) {
 messenger.accountLinking = accountLinking;
 
 function accountLinkingLinked<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) {
   return route(
     (context: C) =>
@@ -80,7 +86,7 @@ function accountLinkingLinked<C extends Context<any, any>>(
 accountLinking.linked = accountLinkingLinked;
 
 function accountLinkingUnlinked<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) {
   return route(
     (context: C) =>
@@ -93,7 +99,9 @@ function accountLinkingUnlinked<C extends Context<any, any>>(
 
 accountLinking.unlinked = accountLinkingUnlinked;
 
-function checkoutUpdate<C extends Context<any, any>>(action: Action<C, any>) {
+function checkoutUpdate<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isCheckoutUpdate,
@@ -103,7 +111,9 @@ function checkoutUpdate<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.checkoutUpdate = checkoutUpdate;
 
-function delivery<C extends Context<any, any>>(action: Action<C, any>) {
+function delivery<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isDelivery,
@@ -113,7 +123,9 @@ function delivery<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.delivery = delivery;
 
-function echo<C extends Context<any, any>>(action: Action<C, any>) {
+function echo<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) => context.platform === 'messenger' && context.event.isEcho,
     action
@@ -122,7 +134,9 @@ function echo<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.echo = echo;
 
-function gamePlay<C extends Context<any, any>>(action: Action<C, any>) {
+function gamePlay<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isGamePlay,
@@ -133,7 +147,7 @@ function gamePlay<C extends Context<any, any>>(action: Action<C, any>) {
 messenger.gamePlay = gamePlay;
 
 function passThreadControl<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) {
   return route(
     (context: C) =>
@@ -145,7 +159,7 @@ function passThreadControl<C extends Context<any, any>>(
 messenger.passThreadControl = passThreadControl;
 
 function takeThreadControl<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) {
   return route(
     (context: C) =>
@@ -157,7 +171,7 @@ function takeThreadControl<C extends Context<any, any>>(
 messenger.takeThreadControl = takeThreadControl;
 
 function requestThreadControl<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) {
   return route(
     (context: C) =>
@@ -168,7 +182,9 @@ function requestThreadControl<C extends Context<any, any>>(
 
 messenger.requestThreadControl = requestThreadControl;
 
-function appRoles<C extends Context<any, any>>(action: Action<C, any>) {
+function appRoles<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isAppRoles,
@@ -178,7 +194,9 @@ function appRoles<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.appRoles = appRoles;
 
-function optin<C extends Context<any, any>>(action: Action<C, any>) {
+function optin<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) => context.platform === 'messenger' && context.event.isOptin,
     action
@@ -187,7 +205,9 @@ function optin<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.optin = optin;
 
-function payment<C extends Context<any, any>>(action: Action<C, any>) {
+function payment<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) => context.platform === 'messenger' && context.event.isPayment,
     action
@@ -197,7 +217,7 @@ function payment<C extends Context<any, any>>(action: Action<C, any>) {
 messenger.payment = payment;
 
 function policyEnforcement<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<MessengerContext, any>
 ) {
   return route(
     (context: C) =>
@@ -208,7 +228,9 @@ function policyEnforcement<C extends Context<any, any>>(
 
 messenger.policyEnforcement = policyEnforcement;
 
-function postback<C extends Context<any, any>>(action: Action<C, any>) {
+function postback<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isPostback,
@@ -218,7 +240,9 @@ function postback<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.postback = postback;
 
-function preCheckout<C extends Context<any, any>>(action: Action<C, any>) {
+function preCheckout<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isPreCheckout,
@@ -228,7 +252,9 @@ function preCheckout<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.preCheckout = preCheckout;
 
-function read<C extends Context<any, any>>(action: Action<C, any>) {
+function read<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) => context.platform === 'messenger' && context.event.isRead,
     action
@@ -237,7 +263,9 @@ function read<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.read = read;
 
-function referral<C extends Context<any, any>>(action: Action<C, any>) {
+function referral<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isReferral,
@@ -247,7 +275,9 @@ function referral<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.referral = referral;
 
-function standby<C extends Context<any, any>>(action: Action<C, any>) {
+function standby<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) => context.platform === 'messenger' && context.event.isStandby,
     action
@@ -256,7 +286,9 @@ function standby<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.standby = standby;
 
-function reaction<C extends Context<any, any>>(action: Action<C, any>) {
+function reaction<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' && context.event.isReaction,
@@ -266,7 +298,9 @@ function reaction<C extends Context<any, any>>(action: Action<C, any>) {
 
 messenger.reaction = reaction;
 
-function reactionReact<C extends Context<any, any>>(action: Action<C, any>) {
+function reactionReact<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' &&
@@ -278,7 +312,9 @@ function reactionReact<C extends Context<any, any>>(action: Action<C, any>) {
 
 reaction.react = reactionReact;
 
-function reactionUnreact<C extends Context<any, any>>(action: Action<C, any>) {
+function reactionUnreact<C extends Context<any, any>>(
+  action: Action<MessengerContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'messenger' &&

--- a/packages/bottender/src/router/index.ts
+++ b/packages/bottender/src/router/index.ts
@@ -15,9 +15,9 @@ export type RoutePredicate<C extends Context<any, any>> = (
   context: C
 ) => boolean | Record<string, any> | Promise<boolean | Record<string, any>>;
 
-type Route<C extends Context<any, any>> = {
+type Route<C extends Context<any, any>, AC extends Context<any, any> = C> = {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<AC, any>;
 };
 
 function router<C extends Context<any, any>>(routes: Route<C>[]) {
@@ -39,9 +39,9 @@ function router<C extends Context<any, any>>(routes: Route<C>[]) {
   };
 }
 
-function route<C extends Context<any, any>>(
+function route<C extends Context<any, any>, AC extends Context<any, any> = C>(
   pattern: RoutePattern<C>,
-  action: Action<C, any>
+  action: Action<AC, any>
 ) {
   if (pattern === '*') {
     return {

--- a/packages/bottender/src/slack/routes.ts
+++ b/packages/bottender/src/slack/routes.ts
@@ -2,13 +2,14 @@ import Context from '../context/Context';
 import { Action } from '../types';
 import { RoutePredicate, route } from '../router';
 
+import SlackContext from './SlackContext';
 import { EventTypes } from './SlackEvent';
 
 type Route = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<SlackContext, any>
 ) => {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<SlackContext, any>;
 };
 
 type Slack = Route & {
@@ -16,27 +17,31 @@ type Slack = Route & {
   message: Route;
   event: <C extends Context<any, any>>(
     eventType: EventTypes,
-    action: Action<C, any>
+    action: Action<SlackContext, any>
   ) => {
     predicate: RoutePredicate<C>;
-    action: Action<C, any>;
+    action: Action<SlackContext, any>;
   };
   command: <C extends Context<any, any>>(
     commandText: string,
-    action: Action<C, any>
+    action: Action<SlackContext, any>
   ) => {
     predicate: RoutePredicate<C>;
-    action: Action<C, any>;
+    action: Action<SlackContext, any>;
   };
 };
 
-const slack: Slack = <C extends Context<any, any>>(action: Action<C, any>) => {
+const slack: Slack = <C extends Context<any, any>>(
+  action: Action<SlackContext, any>
+) => {
   return route((context: C) => context.platform === 'slack', action);
 };
 
 slack.any = slack;
 
-function message<C extends Context<any, any>>(action: Action<C, any>) {
+function message<C extends Context<any, any>>(
+  action: Action<SlackContext, any>
+) {
   return route(
     (context: C) => context.platform === 'slack' && context.event.isMessage,
     action
@@ -47,7 +52,7 @@ slack.message = message;
 
 function event<C extends Context<any, any>>(
   eventType: EventTypes,
-  action: Action<C, any>
+  action: Action<SlackContext, any>
 ) {
   return route(
     (context: C) =>
@@ -60,7 +65,7 @@ slack.event = event;
 
 function command<C extends Context<any, any>>(
   commandText: string,
-  action: Action<C, any>
+  action: Action<SlackContext, any>
 ) {
   return route(
     (context: C) =>

--- a/packages/bottender/src/telegram/routes.ts
+++ b/packages/bottender/src/telegram/routes.ts
@@ -2,11 +2,13 @@ import Context from '../context/Context';
 import { Action } from '../types';
 import { RoutePredicate, route } from '../router';
 
+import TelegramContext from './TelegramContext';
+
 type Route = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<TelegramContext, any>
 ) => {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<TelegramContext, any>;
 };
 
 type Telegram = Route & {
@@ -24,14 +26,16 @@ type Telegram = Route & {
 };
 
 const telegram: Telegram = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<TelegramContext, any>
 ) => {
-  return route(context => context.platform === 'telegram', action);
+  return route((context: C) => context.platform === 'telegram', action);
 };
 
 telegram.any = telegram;
 
-function message<C extends Context<any, any>>(action: Action<C, any>) {
+function message<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) => context.platform === 'telegram' && context.event.isMessage,
     action
@@ -40,7 +44,9 @@ function message<C extends Context<any, any>>(action: Action<C, any>) {
 
 telegram.message = message;
 
-function editedMessage<C extends Context<any, any>>(action: Action<C, any>) {
+function editedMessage<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'telegram' && context.event.isEditedMessage,
@@ -50,7 +56,9 @@ function editedMessage<C extends Context<any, any>>(action: Action<C, any>) {
 
 telegram.editedMessage = editedMessage;
 
-function channelPost<C extends Context<any, any>>(action: Action<C, any>) {
+function channelPost<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'telegram' && context.event.isChannelPost,
@@ -61,7 +69,7 @@ function channelPost<C extends Context<any, any>>(action: Action<C, any>) {
 telegram.channelPost = channelPost;
 
 function editedChannelPost<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<TelegramContext, any>
 ) {
   return route(
     (context: C) =>
@@ -72,7 +80,9 @@ function editedChannelPost<C extends Context<any, any>>(
 
 telegram.editedChannelPost = editedChannelPost;
 
-function inlineQuery<C extends Context<any, any>>(action: Action<C, any>) {
+function inlineQuery<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'telegram' && context.event.isInlineQuery,
@@ -83,7 +93,7 @@ function inlineQuery<C extends Context<any, any>>(action: Action<C, any>) {
 telegram.inlineQuery = inlineQuery;
 
 function chosenInlineResult<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<TelegramContext, any>
 ) {
   return route(
     (context: C) =>
@@ -94,7 +104,9 @@ function chosenInlineResult<C extends Context<any, any>>(
 
 telegram.chosenInlineResult = chosenInlineResult;
 
-function callbackQuery<C extends Context<any, any>>(action: Action<C, any>) {
+function callbackQuery<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'telegram' && context.event.isCallbackQuery,
@@ -104,7 +116,9 @@ function callbackQuery<C extends Context<any, any>>(action: Action<C, any>) {
 
 telegram.callbackQuery = callbackQuery;
 
-function shippingQuery<C extends Context<any, any>>(action: Action<C, any>) {
+function shippingQuery<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'telegram' && context.event.isShippingQuery,
@@ -114,7 +128,9 @@ function shippingQuery<C extends Context<any, any>>(action: Action<C, any>) {
 
 telegram.shippingQuery = shippingQuery;
 
-function preCheckoutQuery<C extends Context<any, any>>(action: Action<C, any>) {
+function preCheckoutQuery<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'telegram' && context.event.isPreCheckoutQuery,
@@ -124,7 +140,9 @@ function preCheckoutQuery<C extends Context<any, any>>(action: Action<C, any>) {
 
 telegram.preCheckoutQuery = preCheckoutQuery;
 
-function poll<C extends Context<any, any>>(action: Action<C, any>) {
+function poll<C extends Context<any, any>>(
+  action: Action<TelegramContext, any>
+) {
   return route(
     (context: C) => context.platform === 'telegram' && context.event.isPoll,
     action

--- a/packages/bottender/src/viber/routes.ts
+++ b/packages/bottender/src/viber/routes.ts
@@ -2,11 +2,13 @@ import Context from '../context/Context';
 import { Action } from '../types';
 import { RoutePredicate, route } from '../router';
 
+import ViberContext from './ViberContext';
+
 type Route = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<ViberContext, any>
 ) => {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<ViberContext, any>;
 };
 
 type Viber = Route & {
@@ -20,13 +22,17 @@ type Viber = Route & {
   failed: Route;
 };
 
-const viber: Viber = <C extends Context<any, any>>(action: Action<C, any>) => {
-  return route(context => context.platform === 'viber', action);
+const viber: Viber = <C extends Context<any, any>>(
+  action: Action<ViberContext, any>
+) => {
+  return route((context: C) => context.platform === 'viber', action);
 };
 
 viber.any = viber;
 
-function message<C extends Context<any, any>>(action: Action<C, any>) {
+function message<C extends Context<any, any>>(
+  action: Action<ViberContext, any>
+) {
   return route(
     (context: C) => context.platform === 'viber' && context.event.isMessage,
     action
@@ -35,7 +41,9 @@ function message<C extends Context<any, any>>(action: Action<C, any>) {
 
 viber.message = message;
 
-function subscribed<C extends Context<any, any>>(action: Action<C, any>) {
+function subscribed<C extends Context<any, any>>(
+  action: Action<ViberContext, any>
+) {
   return route(
     (context: C) => context.platform === 'viber' && context.event.isSubscribed,
     action
@@ -44,7 +52,9 @@ function subscribed<C extends Context<any, any>>(action: Action<C, any>) {
 
 viber.subscribed = subscribed;
 
-function unsubscribed<C extends Context<any, any>>(action: Action<C, any>) {
+function unsubscribed<C extends Context<any, any>>(
+  action: Action<ViberContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'viber' && context.event.isUnsubscribed,
@@ -55,7 +65,7 @@ function unsubscribed<C extends Context<any, any>>(action: Action<C, any>) {
 viber.unsubscribed = unsubscribed;
 
 function conversationStarted<C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<ViberContext, any>
 ) {
   return route(
     (context: C) =>
@@ -66,7 +76,9 @@ function conversationStarted<C extends Context<any, any>>(
 
 viber.conversationStarted = conversationStarted;
 
-function delivered<C extends Context<any, any>>(action: Action<C, any>) {
+function delivered<C extends Context<any, any>>(
+  action: Action<ViberContext, any>
+) {
   return route(
     (context: C) => context.platform === 'viber' && context.event.delivered,
     action
@@ -75,7 +87,7 @@ function delivered<C extends Context<any, any>>(action: Action<C, any>) {
 
 viber.delivered = delivered;
 
-function seen<C extends Context<any, any>>(action: Action<C, any>) {
+function seen<C extends Context<any, any>>(action: Action<ViberContext, any>) {
   return route(
     (context: C) => context.platform === 'viber' && context.event.seen,
     action
@@ -84,7 +96,9 @@ function seen<C extends Context<any, any>>(action: Action<C, any>) {
 
 viber.seen = seen;
 
-function failed<C extends Context<any, any>>(action: Action<C, any>) {
+function failed<C extends Context<any, any>>(
+  action: Action<ViberContext, any>
+) {
   return route(
     (context: C) => context.platform === 'viber' && context.event.failed,
     action

--- a/packages/bottender/src/whatsapp/routes.ts
+++ b/packages/bottender/src/whatsapp/routes.ts
@@ -2,11 +2,13 @@ import Context from '../context/Context';
 import { Action } from '../types';
 import { RoutePredicate, route } from '../router';
 
+import WhatsappContext from './WhatsappContext';
+
 type Route = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<WhatsappContext, any>
 ) => {
   predicate: RoutePredicate<C>;
-  action: Action<C, any>;
+  action: Action<WhatsappContext, any>;
 };
 
 type Whatsapp = Route & {
@@ -20,14 +22,16 @@ type Whatsapp = Route & {
 };
 
 const whatsapp: Whatsapp = <C extends Context<any, any>>(
-  action: Action<C, any>
+  action: Action<WhatsappContext, any>
 ) => {
-  return route(context => context.platform === 'whatsapp', action);
+  return route((context: C) => context.platform === 'whatsapp', action);
 };
 
 whatsapp.any = whatsapp;
 
-function message<C extends Context<any, any>>(action: Action<C, any>) {
+function message<C extends Context<any, any>>(
+  action: Action<WhatsappContext, any>
+) {
   return route(
     (context: C) => context.platform === 'whatsapp' && context.event.isMessage,
     action
@@ -36,7 +40,9 @@ function message<C extends Context<any, any>>(action: Action<C, any>) {
 
 whatsapp.message = message;
 
-function media<C extends Context<any, any>>(action: Action<C, any>) {
+function media<C extends Context<any, any>>(
+  action: Action<WhatsappContext, any>
+) {
   return route(
     (context: C) => context.platform === 'whatsapp' && context.event.isMedia,
     action
@@ -45,7 +51,9 @@ function media<C extends Context<any, any>>(action: Action<C, any>) {
 
 whatsapp.media = media;
 
-function received<C extends Context<any, any>>(action: Action<C, any>) {
+function received<C extends Context<any, any>>(
+  action: Action<WhatsappContext, any>
+) {
   return route(
     (context: C) => context.platform === 'whatsapp' && context.event.isReceived,
     action
@@ -54,7 +62,9 @@ function received<C extends Context<any, any>>(action: Action<C, any>) {
 
 whatsapp.received = received;
 
-function sent<C extends Context<any, any>>(action: Action<C, any>) {
+function sent<C extends Context<any, any>>(
+  action: Action<WhatsappContext, any>
+) {
   return route(
     (context: C) => context.platform === 'whatsapp' && context.event.isSent,
     action
@@ -63,7 +73,9 @@ function sent<C extends Context<any, any>>(action: Action<C, any>) {
 
 whatsapp.sent = sent;
 
-function delivered<C extends Context<any, any>>(action: Action<C, any>) {
+function delivered<C extends Context<any, any>>(
+  action: Action<WhatsappContext, any>
+) {
   return route(
     (context: C) =>
       context.platform === 'whatsapp' && context.event.isDelivered,
@@ -73,7 +85,9 @@ function delivered<C extends Context<any, any>>(action: Action<C, any>) {
 
 whatsapp.delivered = delivered;
 
-function read<C extends Context<any, any>>(action: Action<C, any>) {
+function read<C extends Context<any, any>>(
+  action: Action<WhatsappContext, any>
+) {
   return route(
     (context: C) => context.platform === 'whatsapp' && context.event.isRead,
     action


### PR DESCRIPTION
```js
import { MessengerContext, LineContext } from 'bottender';
import { messenger, line, router } from 'bottender/router';

function MessnegerAction(context: MessengerContext): void {}
function LineAction(context: LineContext): void {}
function BothAction(context: MessengerContext | LineContext): void {}

export default async function App(
  context:
    | MessengerContext
    | LineContext
): Promise<any> {
  return router([
    messenger(MessnegerAction), // pass
    messenger(LineAction), // fail
    messenger(BothAction), // pass
    line(MessnegerAction), // fail
    line(LineAction), // pass
    line(BothAction), // pass
  ]);
}
```