### PR TITLE
feat(SessionStore): support custom session store

### DIFF
--- a/packages/bottender/src/__tests__/getSessionStore.spec.ts
+++ b/packages/bottender/src/__tests__/getSessionStore.spec.ts
@@ -1,3 +1,4 @@
+import MemorySessionStore from '../session/MemorySessionStore';
 import getBottenderConfig from '../shared/getBottenderConfig';
 import getSessionStore from '../getSessionStore';
 import { SessionDriver } from '../types';
@@ -71,4 +72,19 @@ it('should get RedisSessionStore when assigning redis as driver', () => {
     },
   });
   expect(getSessionStore().constructor.name).toEqual('RedisSessionStore');
+});
+
+it('should get provided SessionStore when assigning custom driver', () => {
+  const memory2SessionStore = new MemorySessionStore();
+
+  getBottenderConfigMocked.mockReturnValueOnce({
+    session: {
+      driver: 'memory2',
+      stores: {
+        memory2: memory2SessionStore,
+      },
+    },
+  });
+
+  expect(getSessionStore()).toEqual(memory2SessionStore);
 });

--- a/packages/bottender/src/getSessionStore.ts
+++ b/packages/bottender/src/getSessionStore.ts
@@ -1,8 +1,9 @@
 import warning from 'warning';
 
+import SessionStore from './session/SessionStore';
 import getBottenderConfig from './shared/getBottenderConfig';
 
-function getSessionStore() {
+function getSessionStore(): SessionStore {
   const { session } = getBottenderConfig();
 
   const sessionDriver = (session && session.driver) || 'memory';
@@ -44,6 +45,14 @@ function getSessionStore() {
       );
     }
     default: {
+      // Support custom session stores by returning the session store instance
+      const customSessionStore:
+        | SessionStore
+        | undefined = (storesConfig as any)[sessionDriver];
+      if (customSessionStore) {
+        return customSessionStore;
+      }
+
       warning(
         false,
         `Received unknown driver: ${sessionDriver}, so fallback it to \`memory\` driver.`

--- a/packages/bottender/src/types.ts
+++ b/packages/bottender/src/types.ts
@@ -8,6 +8,7 @@ import ConsoleEvent, { ConsoleRawEvent } from './console/ConsoleEvent';
 import Context from './context/Context';
 import LineEvent from './line/LineEvent';
 import MessengerEvent from './messenger/MessengerEvent';
+import SessionStore from './session/SessionStore';
 import SlackEvent from './slack/SlackEvent';
 import TelegramEvent from './telegram/TelegramEvent';
 import TwilioClient from './whatsapp/TwilioClient';
@@ -81,26 +82,30 @@ export enum SessionDriver {
 }
 
 export type SessionConfig = {
-  driver: SessionDriver;
+  driver: string;
   expiresIn?: number;
-  stores: {
-    memory?: {
-      maxSize?: number;
-    };
-    file?: {
-      dirname?: string;
-    };
-    redis?: {
-      port?: number;
-      host?: string;
-      password?: string;
-      db?: number;
-    };
-    mongo?: {
-      url?: string;
-      collectionName?: string;
-    };
-  };
+  stores:
+    | {
+        memory?: {
+          maxSize?: number;
+        };
+        file?: {
+          dirname?: string;
+        };
+        redis?: {
+          port?: number;
+          host?: string;
+          password?: string;
+          db?: number;
+        };
+        mongo?: {
+          url?: string;
+          collectionName?: string;
+        };
+      }
+    | {
+        [P in Exclude<string, SessionDriver>]: SessionStore;
+      };
 };
 
 export type BottenderConfig = {


### PR DESCRIPTION
For example, use a user-defined string as driver:

```js
const { MemorySessionStore } = require('bottender');

module.exports = {
  session: {
    driver: 'memory2',
    stores: {
      memory2: new MemorySessionStore();
    },
  },
};
```

#338