### PR TITLE
fix(type): fix Cannot use namespace 'EventEmitter' as a type

### DIFF
--- a/packages/bottender/src/bot/Bot.ts
+++ b/packages/bottender/src/bot/Bot.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import debug from 'debug';
 import invariant from 'invariant';

--- a/packages/bottender/src/bot/Connector.ts
+++ b/packages/bottender/src/bot/Connector.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import Session from '../session/Session';
 import { Event } from '../context/Event';

--- a/packages/bottender/src/console/ConsoleConnector.ts
+++ b/packages/bottender/src/console/ConsoleConnector.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import Session from '../session/Session';
 import { Connector } from '../bot/Connector';

--- a/packages/bottender/src/console/ConsoleContext.ts
+++ b/packages/bottender/src/console/ConsoleContext.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import sleep from 'delay';
 

--- a/packages/bottender/src/context/Context.ts
+++ b/packages/bottender/src/context/Context.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import cloneDeep from 'lodash/cloneDeep';
 import debug from 'debug';

--- a/packages/bottender/src/line/LineConnector.ts
+++ b/packages/bottender/src/line/LineConnector.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'events';
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
 import warning from 'warning';

--- a/packages/bottender/src/line/LineContext.ts
+++ b/packages/bottender/src/line/LineContext.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import chunk from 'lodash/chunk';
 import invariant from 'invariant';

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'events';
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
 import { URL } from 'url';
 
 import invariant from 'invariant';

--- a/packages/bottender/src/messenger/MessengerContext.ts
+++ b/packages/bottender/src/messenger/MessengerContext.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
 import sleep from 'delay';

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'events';
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
 import pProps from 'p-props';

--- a/packages/bottender/src/slack/SlackContext.ts
+++ b/packages/bottender/src/slack/SlackContext.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import sleep from 'delay';
 import warning from 'warning';

--- a/packages/bottender/src/telegram/TelegramConnector.ts
+++ b/packages/bottender/src/telegram/TelegramConnector.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
 import { TelegramClient } from 'messaging-api-telegram';

--- a/packages/bottender/src/viber/ViberConnector.ts
+++ b/packages/bottender/src/viber/ViberConnector.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'events';
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
 import { ViberClient, ViberTypes } from 'messaging-api-viber';

--- a/packages/bottender/src/whatsapp/WhatsappConnector.ts
+++ b/packages/bottender/src/whatsapp/WhatsappConnector.ts
@@ -1,5 +1,5 @@
-import EventEmitter from 'events';
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
 
 import Session from '../session/Session';
 import { Connector } from '../bot/Connector';


### PR DESCRIPTION
Somehow previous one has been broken in recent TS types, so this is a fix to it: 
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41353#issuecomment-579381008