### PR TITLE
fix(ci): fix docker_default reference duplicate key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2
 # Reference variables.
 references:
-  docker_default: &docker_12
+  docker_12: &docker_12
     working_directory: /tmp/app
     docker:
       - image: node:12
     environment:
       TZ: "/usr/share/zoneinfo/Asia/Taipei"
-  docker_default: &docker_10
+  docker_10: &docker_10
     working_directory: /tmp/app
     docker:
       - image: node:10


### PR DESCRIPTION
It seems Circle CI has changed its yaml parser recently. We need to fix our config to fix parsing error.

fix recent build fails like below ones:
https://circleci.com/gh/Yoctol/bottender/13075
https://circleci.com/gh/Yoctol/bottender/13077