### PR TITLE
fix(line): bump messaging-api-line to beta.20 and fix types in text methods

### DIFF
--- a/packages/bottender/package.json
+++ b/packages/bottender/package.json
@@ -66,7 +66,7 @@
     "lodash": "^4.17.15",
     "lru-cache": "^5.1.1",
     "messaging-api-common": "^1.0.0-beta.16",
-    "messaging-api-line": "^1.0.0-beta.19",
+    "messaging-api-line": "^1.0.0-beta.20",
     "messaging-api-messenger": "^1.0.0-beta.18",
     "messaging-api-slack": "^1.0.0-beta.16",
     "messaging-api-telegram": "^1.0.0-beta.16",

--- a/packages/bottender/src/line/LineContext.ts
+++ b/packages/bottender/src/line/LineContext.ts
@@ -461,7 +461,10 @@ class LineContext extends Context<LineClient, LineEvent> {
     });
   }
 
-  replyText(text: string, options?: LineTypes.MessageOptions) {
+  replyText(
+    text: string,
+    options?: LineTypes.MessageOptions & { emojis?: LineTypes.Emoji[] }
+  ) {
     return this.reply([Line.createText(text, options)], options);
   }
 
@@ -624,7 +627,10 @@ class LineContext extends Context<LineClient, LineEvent> {
     });
   }
 
-  pushText(text: string, options?: LineTypes.MessageOptions) {
+  pushText(
+    text: string,
+    options?: LineTypes.MessageOptions & { emojis?: LineTypes.Emoji[] }
+  ) {
     return this.push([Line.createText(text, options)], options);
   }
 
@@ -774,7 +780,10 @@ class LineContext extends Context<LineClient, LineEvent> {
     return this.reply(messages, options);
   }
 
-  sendText(text: string, options?: LineTypes.MessageOptions) {
+  sendText(
+    text: string,
+    options?: LineTypes.MessageOptions & { emojis?: LineTypes.Emoji[] }
+  ) {
     return this.send([Line.createText(text, options)], options);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7379,10 +7379,10 @@ messaging-api-common@^1.0.0-beta.16:
     snake-case "^3.0.3"
     url-join "^4.0.1"
 
-messaging-api-line@^1.0.0-beta.19:
-  version "1.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/messaging-api-line/-/messaging-api-line-1.0.0-beta.19.tgz#0236e1dc02993f70c79b21849fbb68a210809fdf"
-  integrity sha512-HC7YkwwptrBvEFS+F31NgHOx8wNuqq5BXmQuDuJG6I5oNLA/WOnpD7NURvJXaMK/u7sE1faXyv0PoTw55Un0+Q==
+messaging-api-line@^1.0.0-beta.20:
+  version "1.0.0-beta.20"
+  resolved "https://registry.yarnpkg.com/messaging-api-line/-/messaging-api-line-1.0.0-beta.20.tgz#7470ff978b43ccf0d7d291cd74c0008c78a1284d"
+  integrity sha512-LNWdAc59YuMh5pp4QZkO692pdkpXe6UOLwcXWNu6ABSxZoJnO6ss49m9bQcx6p8nOc5xbnRqIJAyRt3uNDNxAA==
   dependencies:
     axios "^0.19.2"
     axios-error "^1.0.0-beta.16"


### PR DESCRIPTION

https://developers.line.biz/en/news/2020/04/14/messaging-api-update-april-2020/#news-updated-messaging-api-update-for-april-2020

- bump messaging-api-line to beta.20
- fix types in text methods