### PR TITLE
refactor: use bottender function in bottender start instead of initializeServer

### DIFF
--- a/packages/bottender/package.json
+++ b/packages/bottender/package.json
@@ -44,6 +44,7 @@
     "arg": "^4.1.3",
     "axios": "^0.19.2",
     "axios-error": "^1.0.0-beta.16",
+    "body-parser": "^1.19.0",
     "chalk": "~2.4.2",
     "cli-table3": "^0.5.1",
     "date-fns": "^2.10.0",


### PR DESCRIPTION
`initializeServer` is an undocumented helper function I introduced in early v1 (1.0-alpha). After we released custom server support, we supposed to rewrite the whole `initializeServer` with the `bottender` function. However, `initializeServer` is a synchronous function can't be written to asynchronous function without break the return value.

So, I switched the implementation under bottender start/dev to   the `bottender` function. and maybe rewrite `initializeServer` in v2.