### PR TITLE
type(connectors): return literal string instead of string in connector.platform

### DIFF
--- a/packages/bottender/src/line/LineConnector.ts
+++ b/packages/bottender/src/line/LineConnector.ts
@@ -115,7 +115,7 @@ export default class LineConnector
     );
   }
 
-  get platform(): string {
+  get platform(): 'line' {
     return 'line';
   }
 

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -230,7 +230,7 @@ export default class MessengerConnector
     }
   }
 
-  get platform(): string {
+  get platform(): 'messenger' {
     return 'messenger';
   }
 

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -142,7 +142,7 @@ export default class SlackConnector
     );
   }
 
-  get platform(): string {
+  get platform(): 'slack' {
     return 'slack';
   }
 

--- a/packages/bottender/src/telegram/TelegramConnector.ts
+++ b/packages/bottender/src/telegram/TelegramConnector.ts
@@ -59,7 +59,7 @@ export default class TelegramConnector
     return body;
   }
 
-  get platform(): string {
+  get platform(): 'telegram' {
     return 'telegram';
   }
 

--- a/packages/bottender/src/viber/ViberConnector.ts
+++ b/packages/bottender/src/viber/ViberConnector.ts
@@ -69,7 +69,7 @@ export default class ViberConnector
     return body;
   }
 
-  get platform(): string {
+  get platform(): 'viber' {
     return 'viber';
   }
 

--- a/packages/bottender/src/whatsapp/WhatsappConnector.ts
+++ b/packages/bottender/src/whatsapp/WhatsappConnector.ts
@@ -61,7 +61,7 @@ export default class WhatsappConnector
     }
   }
 
-  get platform(): string {
+  get platform(): 'whatsapp' {
     return 'whatsapp';
   }
 


### PR DESCRIPTION
This helps TS get better understanding of the `connector.platform` value.