### PR TITLE
fix(Server): should await for connector.preprocess

### DIFF
--- a/packages/bottender/src/server/Server.ts
+++ b/packages/bottender/src/server/Server.ts
@@ -146,7 +146,8 @@ class Server {
           url: `https://${req.headers.host}${req.url}`,
         };
 
-        const result = (bot.connector as any).preprocess(httpContext);
+        // eslint-disable-next-line no-await-in-loop
+        const result = await (bot.connector as any).preprocess(httpContext);
 
         const { shouldNext } = result;
         let { response } = result;


### PR DESCRIPTION
This is a mistake in the previous PR.