### PR TITLE
feat(LineConnector): add getSessionKeyPrefix to avoid conflict between channels in the same provider

### DIFF
--- a/examples/line-multiple-channels/bottender.config.js
+++ b/examples/line-multiple-channels/bottender.config.js
@@ -3,6 +3,13 @@ module.exports = {
     line: {
       enabled: true,
       path: '/webhooks/line/:channelId',
+
+      // [Optional] If you want to avoid user id conflict between LINE channels in the same provider,
+      // you must add prefix to the session keys using the parameters from the URL
+      getSessionKeyPrefix({ params }) {
+        return `${params.channelId}:`;
+      },
+
       async getConfig({ params }) {
         switch (params.channelId) {
           case process.env.CHANNEL_2_CHANNEL_ID:

--- a/examples/line-multiple-channels/bottender.config.js
+++ b/examples/line-multiple-channels/bottender.config.js
@@ -6,8 +6,10 @@ module.exports = {
 
       // [Optional] If you want to avoid user id conflict between LINE channels in the same provider,
       // you must add prefix to the session keys using the parameters from the URL
-      getSessionKeyPrefix({ params }) {
+      getSessionKeyPrefix(event, { params }) {
         return `${params.channelId}:`;
+        // or you can use the destination to avoid the conflict
+        // return `${event.destination}:`;
       },
 
       async getConfig({ params }) {

--- a/packages/bottender/src/line/__tests__/LineConnector.spec.ts
+++ b/packages/bottender/src/line/__tests__/LineConnector.spec.ts
@@ -2,7 +2,10 @@ import warning from 'warning';
 import { LineClient } from 'messaging-api-line';
 import { mocked } from 'ts-jest/utils';
 
-import LineConnector, { LineRequestBody } from '../LineConnector';
+import LineConnector, {
+  GetSessionKeyPrefixFunction,
+  LineRequestBody,
+} from '../LineConnector';
 import LineContext from '../LineContext';
 import LineEvent from '../LineEvent';
 
@@ -88,15 +91,18 @@ beforeEach(() => {
 function setup({
   sendMethod,
   skipLegacyProfile,
+  getSessionKeyPrefix,
 }: {
   sendMethod?: string;
   skipLegacyProfile?: boolean;
+  getSessionKeyPrefix?: GetSessionKeyPrefixFunction;
 } = {}) {
   const connector = new LineConnector({
     accessToken: ACCESS_TOKEN,
     channelSecret: CHANNEL_SECRET,
     sendMethod,
     skipLegacyProfile,
+    getSessionKeyPrefix,
   });
 
   const client = mocked(LineClient).mock.instances[0];
@@ -214,6 +220,44 @@ describe('#getUniqueSessionKey', () => {
     );
 
     expect(senderId).toBe('U206d25c2ea6bd87c17655609a1c37cb8');
+  });
+
+  it('should add the prefix to the session key when getSessionKeyPrefix exists', () => {
+    const { connector } = setup({
+      getSessionKeyPrefix: ({ params }) => `${params.channelId}:`,
+    });
+
+    const senderId = connector.getUniqueSessionKey(
+      new LineEvent({
+        replyToken: 'nHuyWiB7yP5Zw52FIkcQobQuGDXCTA',
+        type: 'message',
+        mode: 'active',
+        timestamp: 1462629479859,
+        source: {
+          type: 'user',
+          userId: 'U206d25c2ea6bd87c17655609a1c37cb8',
+        },
+        message: {
+          id: '325708',
+          type: 'text',
+          text: 'Hello, world',
+        },
+      }),
+      {
+        method: 'post',
+        path: '/webhooks/line/CHANNEL_ID',
+        query: {},
+        headers: {},
+        rawBody: '{}',
+        body: {},
+        params: {
+          channelId: 'CHANNEL_ID',
+        },
+        url: 'https://www.example.com/webhooks/line/CHANNEL_ID',
+      }
+    );
+
+    expect(senderId).toBe('CHANNEL_ID:U206d25c2ea6bd87c17655609a1c37cb8');
   });
 });
 


### PR DESCRIPTION
```js
module.exports = {
  channels: {
    line: {
      enabled: true,
      path: '/webhooks/line/:channelId',

      // [Optional] If you want to avoid user id conflict between LINE channels in the same provider,
      // you must add prefix to the session keys using the parameters from the URL
      getSessionKeyPrefix({ params }) {
        return `${params.channelId}:`;
        // or you can use the destination to avoid the conflict
        // return `${event.destination}:`;
      },

      async getConfig({ params }) {
        // ...
      },
    },
  },
};

```