### PR TITLE
fix(messenger cli): remove deprecated properties on messenger profiles (including home_url)

### DIFF
--- a/packages/bottender/src/cli/providers/messenger/__tests__/deleteMessengerProfile.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/deleteMessengerProfile.spec.ts
@@ -51,9 +51,6 @@ describe('resolved', () => {
       'greeting',
       'ice_breakers',
       'whitelisted_domains',
-      'payment_settings',
-      'target_audience',
-      'home_url',
     ]);
   });
 });

--- a/packages/bottender/src/cli/providers/messenger/__tests__/getMessengerProfile.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/getMessengerProfile.spec.ts
@@ -50,9 +50,6 @@ describe('resolved', () => {
       'greeting',
       'ice_breakers',
       'whitelisted_domains',
-      'payment_settings',
-      'target_audience',
-      'home_url',
     ]);
   });
 

--- a/packages/bottender/src/cli/providers/messenger/__tests__/setMessengerProfile.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/setMessengerProfile.spec.ts
@@ -85,9 +85,6 @@ describe('resolve', () => {
         'greeting',
         'ice_breakers',
         'whitelisted_domains',
-        'payment_settings',
-        'target_audience',
-        'home_url',
       ]);
       expect(_client.setMessengerProfile).toBeCalledWith({
         getStarted: {

--- a/packages/bottender/src/cli/providers/messenger/profile.ts
+++ b/packages/bottender/src/cli/providers/messenger/profile.ts
@@ -19,9 +19,6 @@ const FIELDS = [
   'greeting',
   'ice_breakers',
   'whitelisted_domains',
-  'payment_settings',
-  'target_audience',
-  'home_url',
 ];
 
 export const help = (): void => {


### PR DESCRIPTION
#776

> The home_url property on Page Messenger Profiles has been deprecated for all operations (GET, POST, and DELETE).

https://developers.facebook.com/docs/graph-api/changelog/version7.0