### PR TITLE
feat: export FacebookBaseConnector

### DIFF
--- a/packages/bottender/src/__tests__/index.spec.ts
+++ b/packages/bottender/src/__tests__/index.spec.ts
@@ -14,6 +14,7 @@ describe('core', () => {
 
   it('export connectors', () => {
     expect(core.ConsoleConnector).toBeDefined();
+    expect(core.FacebookBaseConnector).toBeDefined();
     expect(core.MessengerConnector).toBeDefined();
     expect(core.WhatsappConnector).toBeDefined();
     expect(core.LineConnector).toBeDefined();

--- a/packages/bottender/src/index.ts
+++ b/packages/bottender/src/index.ts
@@ -33,6 +33,7 @@ export { default as ConsoleEvent } from './console/ConsoleEvent';
 
 /* Messenger */
 export { default as MessengerBot } from './messenger/MessengerBot';
+export { default as FacebookBaseConnector } from './messenger/FacebookBaseConnector';
 export { default as MessengerConnector } from './messenger/MessengerConnector';
 export { default as MessengerContext } from './messenger/MessengerContext';
 export { default as MessengerEvent } from './messenger/MessengerEvent';
@@ -72,6 +73,9 @@ export { default as ViberConnector } from './viber/ViberConnector';
 export { default as ViberContext } from './viber/ViberContext';
 export { default as ViberEvent } from './viber/ViberEvent';
 export { ViberTypes } from 'messaging-api-viber';
+
+/* Types */
+export * from './types';
 
 /**
  * Private Exports (unstable)

--- a/packages/bottender/src/messenger/__tests__/MessengerConnector.spec.ts
+++ b/packages/bottender/src/messenger/__tests__/MessengerConnector.spec.ts
@@ -733,7 +733,7 @@ describe('#preprocess', () => {
         status: 400,
         body: {
           error: {
-            message: 'Messenger Signature Validation Failed!',
+            message: 'Facebook Signature Validation Failed!',
             request: {
               headers: {
                 'x-hub-signature':


### PR DESCRIPTION
Export `FacebookBaseConnector` for experimentally extending other Facebook Webhook APIs besides Messenger.