### PR TITLE
type(JsonObject): use JsonObject instead Record<string, any>

### DIFF
--- a/packages/bottender/src/bot/Bot.ts
+++ b/packages/bottender/src/bot/Bot.ts
@@ -84,7 +84,7 @@ export default class Bot<
 
   _errorHandler: Action<Ctx, any> | null;
 
-  _initialState: Record<string, any> = {};
+  _initialState: JsonObject = {};
 
   _plugins: Function[] = [];
 
@@ -123,7 +123,7 @@ export default class Bot<
     return this._sessions;
   }
 
-  get handler(): Action<Ctx, E> | null {
+  get handler(): Action<Ctx, any> | null {
     return this._handler;
   }
 
@@ -149,7 +149,7 @@ export default class Bot<
     return this;
   }
 
-  setInitialState(initialState: Record<string, any>): Bot<B, C, E, Ctx> {
+  setInitialState(initialState: JsonObject): Bot<B, C, E, Ctx> {
     this._initialState = initialState;
     return this;
   }

--- a/packages/bottender/src/bot/Connector.ts
+++ b/packages/bottender/src/bot/Connector.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
 
+import { JsonObject } from 'type-fest';
+
 import Session from '../session/Session';
 import { Event } from '../context/Event';
 import { RequestContext } from '../types';
@@ -16,7 +18,7 @@ export interface Connector<B, C> {
   createContext(params: {
     event: Event<any>;
     session?: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: RequestContext;
     emitter?: EventEmitter | null;
   }): any;

--- a/packages/bottender/src/cache/CacheStore.ts
+++ b/packages/bottender/src/cache/CacheStore.ts
@@ -1,4 +1,6 @@
-export type CacheValue = number | Record<string, any>;
+import { JsonObject } from 'type-fest';
+
+export type CacheValue = number | JsonObject;
 
 type CacheStore = {
   get(key: string): Promise<CacheValue | null>;

--- a/packages/bottender/src/cli/providers/messenger/__tests__/setWebhook.spec.ts
+++ b/packages/bottender/src/cli/providers/messenger/__tests__/setWebhook.spec.ts
@@ -23,7 +23,10 @@ const WEBHOOK = 'http://example.com/webhook';
 function setup({
   config,
   success = true,
-}: { config?: Record<string, any>; success?: boolean } = {}) {
+}: {
+  config?: Record<string, any>;
+  success?: boolean;
+} = {}) {
   getWebhookFromNgrok.mockResolvedValue('https://fakeDomain.ngrok.io');
 
   getChannelConfig.mockReturnValue(

--- a/packages/bottender/src/console/ConsoleConnector.ts
+++ b/packages/bottender/src/console/ConsoleConnector.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events';
 
+import { JsonObject } from 'type-fest';
+
 import Session from '../session/Session';
 import { Connector } from '../bot/Connector';
 import { RequestContext } from '../types';
@@ -75,7 +77,7 @@ export default class ConsoleConnector
   createContext(params: {
     event: ConsoleEvent;
     session: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: RequestContext;
     emitter: EventEmitter | null;
   }): ConsoleContext {

--- a/packages/bottender/src/console/ConsoleContext.ts
+++ b/packages/bottender/src/console/ConsoleContext.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 
 import sleep from 'delay';
+import { JsonObject } from 'type-fest';
 
 import Context from '../context/Context';
 import Session from '../session/Session';
@@ -13,7 +14,7 @@ type Options = {
   client: ConsoleClient;
   event: ConsoleEvent;
   session: Session | null;
-  initialState?: Record<string, any> | null;
+  initialState?: JsonObject | null;
   requestContext?: RequestContext;
   fallbackMethods: boolean;
   mockPlatform: string;

--- a/packages/bottender/src/context/Context.ts
+++ b/packages/bottender/src/context/Context.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import cloneDeep from 'lodash/cloneDeep';
 import debug from 'debug';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 
 import Session from '../session/Session';
 import { Client, Event, RequestContext } from '../types';
@@ -13,7 +14,7 @@ type Options<C extends Client, E extends Event> = {
   client: C;
   event: E;
   session?: Session | null;
-  initialState?: Record<string, any> | null;
+  initialState?: JsonObject | null;
   requestContext?: RequestContext;
   emitter?: EventEmitter | null;
 };
@@ -35,7 +36,7 @@ export default abstract class Context<
   abstract get platform(): string;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  abstract sendText(text: string, options?: Record<string, any>): any;
+  abstract sendText(text: string, options?: JsonObject): any;
 
   _isHandled: boolean | null = null;
 
@@ -47,7 +48,7 @@ export default abstract class Context<
 
   _session: Session | null;
 
-  _initialState?: Record<string, any> | null;
+  _initialState?: JsonObject | null;
 
   _requestContext: RequestContext | null;
 
@@ -136,7 +137,7 @@ export default abstract class Context<
    * The state of the conversation context.
    *
    */
-  get state(): Record<string, any> {
+  get state(): JsonObject {
     if (this._session) {
       return this._session._state;
     }
@@ -151,7 +152,7 @@ export default abstract class Context<
    * Shallow merge changes to the state.
    *
    */
-  setState(state: Record<string, any>): void {
+  setState(state: JsonObject): void {
     if (this._session) {
       const sess = this._session;
 

--- a/packages/bottender/src/line/LineConnector.ts
+++ b/packages/bottender/src/line/LineConnector.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 import { LineClient } from 'messaging-api-line';
 
 import Session from '../session/Session';
@@ -354,7 +355,7 @@ export default class LineConnector
   async createContext(params: {
     event: LineEvent;
     session?: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: LineRequestContext;
     emitter?: EventEmitter | null;
   }): Promise<LineContext> {

--- a/packages/bottender/src/line/LineContext.ts
+++ b/packages/bottender/src/line/LineContext.ts
@@ -4,6 +4,7 @@ import chunk from 'lodash/chunk';
 import invariant from 'invariant';
 import sleep from 'delay';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 import { Line, LineClient, LineTypes } from 'messaging-api-line';
 
 import Context from '../context/Context';
@@ -16,7 +17,7 @@ type Options = {
   client: LineClient;
   event: LineEvent;
   session?: Session | null;
-  initialState?: Record<string, any> | null;
+  initialState?: JsonObject | null;
   requestContext?: RequestContext;
   customAccessToken?: string;
   shouldBatch?: boolean;

--- a/packages/bottender/src/messenger/MessengerConnector.ts
+++ b/packages/bottender/src/messenger/MessengerConnector.ts
@@ -4,6 +4,7 @@ import { URL } from 'url';
 import isAfter from 'date-fns/isAfter';
 import isValid from 'date-fns/isValid';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 import { MessengerClient } from 'messaging-api-messenger';
 
 import Session from '../session/Session';
@@ -286,7 +287,7 @@ export default class MessengerConnector
   async createContext(params: {
     event: MessengerEvent;
     session?: Session;
-    initialState?: Record<string, any>;
+    initialState?: JsonObject;
     requestContext?: MessengerRequestContext;
     emitter?: EventEmitter;
   }): Promise<MessengerContext> {

--- a/packages/bottender/src/messenger/MessengerContext.ts
+++ b/packages/bottender/src/messenger/MessengerContext.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import invariant from 'invariant';
 import sleep from 'delay';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 import {
   MessengerBatch,
   MessengerClient,
@@ -22,7 +23,7 @@ type Options = {
   client: MessengerClient;
   event: MessengerEvent;
   session?: Session;
-  initialState?: Record<string, any>;
+  initialState?: JsonObject;
   requestContext?: RequestContext;
   customAccessToken?: string;
   batchQueue?: MessengerBatchQueue | null;

--- a/packages/bottender/src/router/index.ts
+++ b/packages/bottender/src/router/index.ts
@@ -1,3 +1,5 @@
+import { JsonObject } from 'type-fest';
+
 import Context from '../context/Context';
 import line from '../line/routes';
 import messenger from '../messenger/routes';
@@ -13,7 +15,7 @@ type RoutePattern<C extends Context> = '*' | RoutePredicate<C>;
 
 export type RoutePredicate<C extends Context> = (
   context: C
-) => boolean | Record<string, any> | Promise<boolean | Record<string, any>>;
+) => boolean | JsonObject | Promise<boolean | JsonObject>;
 
 type Route<C extends Context, AC extends Context = C> = {
   predicate: RoutePredicate<C>;

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import invariant from 'invariant';
 import pProps from 'p-props';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 import { SlackOAuthClient } from 'messaging-api-slack';
 import { camelcaseKeysDeep } from 'messaging-api-common';
 
@@ -340,7 +341,7 @@ export default class SlackConnector
   createContext(params: {
     event: SlackEvent;
     session: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: RequestContext;
     emitter?: EventEmitter | null;
   }): SlackContext {

--- a/packages/bottender/src/slack/SlackContext.ts
+++ b/packages/bottender/src/slack/SlackContext.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 
 import sleep from 'delay';
 import warning from 'warning';
+import { JsonObject } from 'type-fest';
 import { SlackOAuthClient, SlackTypes } from 'messaging-api-slack';
 
 import Context from '../context/Context';
@@ -14,7 +15,7 @@ type Options = {
   client: SlackOAuthClient;
   event: SlackEvent;
   session?: Session | null;
-  initialState?: Record<string, any> | null;
+  initialState?: JsonObject | null;
   requestContext?: RequestContext;
   emitter?: EventEmitter | null;
 };

--- a/packages/bottender/src/telegram/TelegramConnector.ts
+++ b/packages/bottender/src/telegram/TelegramConnector.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
+import { JsonObject } from 'type-fest';
 import { TelegramClient } from 'messaging-api-telegram';
 
 import Session from '../session/Session';
@@ -206,7 +207,7 @@ export default class TelegramConnector
   createContext(params: {
     event: TelegramEvent;
     session: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: TelegramRequestContext;
     emitter?: EventEmitter | null;
   }): TelegramContext {

--- a/packages/bottender/src/types.ts
+++ b/packages/bottender/src/types.ts
@@ -15,8 +15,8 @@ import { WhatsappConnectorOptions } from './whatsapp/WhatsappConnector';
 
 export type Action<
   C extends Context,
-  P extends Record<string, any> = {},
-  RAP extends Record<string, any> = {}
+  P extends JsonObject = {},
+  RAP extends JsonObject = {}
 > = (
   context: C,
   props: Props<C> & P
@@ -82,7 +82,7 @@ type ChannelCommonConfig = {
 export type BottenderConfig = {
   plugins?: Plugin<any>[];
   session?: SessionConfig;
-  initialState?: Record<string, any>;
+  initialState?: JsonObject;
   channels?:
     | {
         messenger?: MessengerConnectorOptions & ChannelCommonConfig;

--- a/packages/bottender/src/viber/ViberConnector.ts
+++ b/packages/bottender/src/viber/ViberConnector.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { EventEmitter } from 'events';
 
 import invariant from 'invariant';
+import { JsonObject } from 'type-fest';
 import { ViberClient, ViberTypes } from 'messaging-api-viber';
 import { addedDiff } from 'deep-object-diff';
 
@@ -154,7 +155,7 @@ export default class ViberConnector
   createContext(params: {
     event: ViberEvent;
     session: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: ViberRequestContext;
     emitter?: EventEmitter | null;
   }): ViberContext {

--- a/packages/bottender/src/whatsapp/WhatsappConnector.ts
+++ b/packages/bottender/src/whatsapp/WhatsappConnector.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import { EventEmitter } from 'events';
 
+import { JsonObject } from 'type-fest';
+
 import Session from '../session/Session';
 import { Connector } from '../bot/Connector';
 import { RequestContext } from '../types';
@@ -105,7 +107,7 @@ export default class WhatsappConnector
   createContext(params: {
     event: WhatsappEvent;
     session: Session | null;
-    initialState?: Record<string, any> | null;
+    initialState?: JsonObject | null;
     requestContext?: RequestContext;
     emitter?: EventEmitter | null;
   }): WhatsappContext {

--- a/packages/bottender/src/withProps.ts
+++ b/packages/bottender/src/withProps.ts
@@ -1,9 +1,10 @@
 import partial from 'lodash/partial';
+import { JsonObject } from 'type-fest';
 
 import Context from './context/Context';
 import { Action } from './types';
 
-function withProps<C extends Context, P extends Record<string, any>>(
+function withProps<C extends Context, P extends JsonObject>(
   action: Action<C, P>,
   props: P
 ): Action<C, any> {


### PR DESCRIPTION
Use `JsonObject` instead of `Record<string, any>` in most of places.