### PR TITLE
ci: run lint only on ubuntu-latest node 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -45,6 +45,7 @@ jobs:
         run: npm run compile
 
       - name: Run lint rules
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 12 }}
         run: npm run lint
 
       - name: Run tests


### PR DESCRIPTION
To avoid showing 6x errors and warnings.

