### PR TITLE
Fix slack session when channel id is null

### DIFF
--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -270,7 +270,7 @@ export default class SlackConnector
         Array.isArray(session.channel.members) &&
         session.channel.members.indexOf(userId) < 0)
     ) {
-      if (channelId != null) {
+      if (channelId) {
         promises.channel = this._client.getConversationInfo(channelId);
         promises.channelMembers = this._client.getAllConversationMembers(
           channelId

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -151,10 +151,8 @@ export default class SlackConnector
     return this._client;
   }
 
-  getUniqueSessionKey(body: SlackRequestBody): string {
-    // FIXME: define types for every slack events
-    const rawEvent = this._getRawEventFromRequest(body) as any;
-
+  // FIXME: define types for every slack events
+  getChannelId(rawEvent: any): string | null {
     // For interactive_message format
     if (
       rawEvent.channel &&
@@ -188,43 +186,52 @@ export default class SlackConnector
     );
   }
 
-  async updateSession(session: Session, body: SlackRequestBody): Promise<void> {
-    if (this._isBotEventRequest(body)) {
-      return;
-    }
-
-    const rawEvent = this._getRawEventFromRequest(body);
-    let userFromBody;
+  getUserId(rawEvent: SlackRawEvent): string | null {
     if (
       rawEvent.type === 'interactive_message' ||
       rawEvent.type === 'block_actions' ||
       rawEvent.type === 'view_submission' ||
       rawEvent.type === 'view_closed'
     ) {
-      userFromBody = (rawEvent as UIEvent).user.id;
-    } else {
-      userFromBody =
-        (rawEvent as Message).user || (rawEvent as CommandEvent).userId;
+      return (rawEvent as UIEvent).user.id;
     }
+    return (
+      (rawEvent as Message).user ||
+      (rawEvent as CommandEvent).userId ||
+      (rawEvent as UIEvent).user.id
+    );
+  }
+
+  getUniqueSessionKey(body: SlackRequestBody): string | null {
+    const rawEvent = this._getRawEventFromRequest(body);
+    return this.getChannelId(rawEvent) || this.getUserId(rawEvent);
+  }
+
+  async updateSession(session: Session, body: SlackRequestBody): Promise<void> {
+    if (this._isBotEventRequest(body)) {
+      return;
+    }
+
+    const rawEvent = this._getRawEventFromRequest(body);
+    const userId = this.getUserId(rawEvent);
+    const channelId = this.getChannelId(rawEvent);
 
     if (
       typeof session.user === 'object' &&
       session.user &&
       session.user.id &&
-      session.user.id === userFromBody
+      session.user.id === userId
     ) {
       return;
     }
-    const channelId = this.getUniqueSessionKey(body);
-    const senderId = userFromBody;
 
-    if (!senderId) {
+    if (!userId) {
       return;
     }
 
     if (this._skipLegacyProfile) {
       session.user = {
-        id: senderId,
+        id: userId,
         _updatedAt: new Date().toISOString(),
       };
 
@@ -253,7 +260,7 @@ export default class SlackConnector
     }
 
     const promises: Record<string, any> = {
-      sender: this._client.getUserInfo(senderId),
+      sender: this._client.getUserInfo(userId),
     };
 
     // TODO: check join or leave events?
@@ -261,12 +268,14 @@ export default class SlackConnector
       !session.channel ||
       (session.channel.members &&
         Array.isArray(session.channel.members) &&
-        session.channel.members.indexOf(senderId) < 0)
+        session.channel.members.indexOf(userId) < 0)
     ) {
-      promises.channel = this._client.getConversationInfo(channelId);
-      promises.channelMembers = this._client.getAllConversationMembers(
-        channelId
-      );
+      if (channelId != null) {
+        promises.channel = this._client.getConversationInfo(channelId);
+        promises.channelMembers = this._client.getAllConversationMembers(
+          channelId
+        );
+      }
     }
 
     // TODO: how to know if user leave team?
@@ -275,7 +284,7 @@ export default class SlackConnector
       !session.team ||
       (session.team.members &&
         Array.isArray(session.team.members) &&
-        session.team.members.indexOf(senderId) < 0)
+        session.team.members.indexOf(userId) < 0)
     ) {
       promises.allUsers = this._client.getAllUserList();
     }
@@ -284,7 +293,7 @@ export default class SlackConnector
 
     // FIXME: refine user
     session.user = {
-      id: senderId,
+      id: userId,
       _updatedAt: new Date().toISOString(),
       ...results.sender,
     };

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -152,7 +152,7 @@ export default class SlackConnector
   }
 
   // FIXME: define types for every slack events
-  getChannelId(rawEvent: any): string | null {
+  _getChannelId(rawEvent: any): string | null {
     // For interactive_message format
     if (
       rawEvent.channel &&
@@ -186,7 +186,7 @@ export default class SlackConnector
     );
   }
 
-  getUserId(rawEvent: SlackRawEvent): string | null {
+  _getUserId(rawEvent: SlackRawEvent): string | null {
     if (
       rawEvent.type === 'interactive_message' ||
       rawEvent.type === 'block_actions' ||
@@ -198,13 +198,13 @@ export default class SlackConnector
     return (
       (rawEvent as Message).user ||
       (rawEvent as CommandEvent).userId ||
-      (rawEvent as UIEvent).user.id
+      (rawEvent as UIEvent).user?.id
     );
   }
 
   getUniqueSessionKey(body: SlackRequestBody): string | null {
     const rawEvent = this._getRawEventFromRequest(body);
-    return this.getChannelId(rawEvent) || this.getUserId(rawEvent);
+    return this._getChannelId(rawEvent) || this._getUserId(rawEvent);
   }
 
   async updateSession(session: Session, body: SlackRequestBody): Promise<void> {
@@ -213,8 +213,8 @@ export default class SlackConnector
     }
 
     const rawEvent = this._getRawEventFromRequest(body);
-    const userId = this.getUserId(rawEvent);
-    const channelId = this.getChannelId(rawEvent);
+    const userId = this._getUserId(rawEvent);
+    const channelId = this._getChannelId(rawEvent);
 
     if (
       typeof session.user === 'object' &&

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -138,6 +138,127 @@ const viewSubmissionRequest = {
   },
 };
 
+const appHomeOpenedOnMessagesTabRequest = {
+  type: 'app_home_opened',
+  user: 'U0HD00000',
+  channel: 'DQMT00000',
+  tab: 'messages',
+  eventTs: '1592278860.498134',
+};
+
+const appHomeOpenedOnHomeTabRequest = {
+  type: 'app_home_opened',
+  user: 'U0HD00000',
+  channel: 'DQMT00000',
+  tab: 'home',
+  view: {
+    id: 'V0151K00000',
+    teamId: 'T0HD00000',
+    type: 'home',
+    blocks: [
+      {
+        type: 'actions',
+        blockId: 'Rm7lr',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'zrZ',
+            text: {
+              type: 'plain_text',
+              text: 'value',
+              emoji: true,
+            },
+            value: 'value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '',
+    callbackId: '',
+    state: { values: {} },
+    hash: '1592278862.48a704aa',
+    title: { type: 'plain_text', text: 'View Title', emoji: true },
+    clearOnClose: false,
+    notifyOnClose: false,
+    close: null,
+    submit: null,
+    previousViewId: null,
+    rootViewId: 'V0151K00000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  eventTs: '1592278910.074390',
+};
+
+const blockActionsOnHomeTabRequest = {
+  type: 'block_actions',
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  container: { type: 'view', viewId: 'V0151K00000' },
+  triggerId: '1192207164308.17443231012.b30e1f98a3ac48b9171d3b859a0124a5',
+  team: { id: 'T0HD00000', domain: 'domain' },
+  view: {
+    id: 'V0151K00000',
+    teamId: 'T0HD00000',
+    type: 'home',
+    blocks: [
+      {
+        type: 'actions',
+        blockId: 'Rm7lr',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'zrZ',
+            text: {
+              type: 'plain_text',
+              text: 'value',
+              emoji: true,
+            },
+            value: 'value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '',
+    callbackId: '',
+    state: { values: {} },
+    hash: '1592278912.3f2f9db2',
+    title: { type: 'plain_text', text: 'View Title', emoji: true },
+    clearOnClose: false,
+    notifyOnClose: false,
+    close: null,
+    submit: null,
+    previousViewId: null,
+    rootViewId: 'V0151K00000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  actions: [
+    {
+      actionId: 'zrZ',
+      blockId: 'Rm7lr',
+      text: {
+        type: 'plain_text',
+        text: 'value',
+        emoji: true,
+      },
+      value: 'value',
+      type: 'button',
+      actionTs: '1592279552.931549',
+    },
+  ],
+};
+
 const RtmMessage = {
   type: 'message',
   channel: 'G7W5WAAAA',
@@ -210,54 +331,75 @@ describe('#client', () => {
 });
 
 describe('#getUniqueSessionKey', () => {
-  it('extract correct channel id', () => {
+  it('extract correct session key', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(request.body);
-    expect(channelId).toBe('C6A900000');
+    const sessionKey = connector.getUniqueSessionKey(request.body);
+    expect(sessionKey).toBe('C6A900000');
   });
 
-  it('extract correct channel id from interactive message request', () => {
+  it('extract correct session key from interactive message request', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(
+    const sessionKey = connector.getUniqueSessionKey(
       interactiveMessageRequest.body
     );
-    expect(channelId).toBe('D7WTL9ECE');
+    expect(sessionKey).toBe('D7WTL9ECE');
   });
 
-  it('extract correct channel id from RTM WebSocket message', () => {
+  it('extract correct session key from RTM WebSocket message', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(RtmMessage);
-    expect(channelId).toBe('G7W5WAAAA');
+    const sessionKey = connector.getUniqueSessionKey(RtmMessage);
+    expect(sessionKey).toBe('G7W5WAAAA');
   });
 
-  it('extract correct channel id from reaction_added event', () => {
+  it('extract correct session key from reaction_added event', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(ReactionAddedRequest.body);
-    expect(channelId).toBe('C0G9QF9GZ');
+    const sessionKey = connector.getUniqueSessionKey(ReactionAddedRequest.body);
+    expect(sessionKey).toBe('C0G9QF9GZ');
   });
 
-  it('extract correct channel id from pin_added event', () => {
+  it('extract correct session key from pin_added event', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(PinAddedRequest.body);
-    expect(channelId).toBe('C02ELGNBH');
+    const sessionKey = connector.getUniqueSessionKey(PinAddedRequest.body);
+    expect(sessionKey).toBe('C02ELGNBH');
   });
 
-  it('extract correct channel id from slash command', () => {
+  it('extract correct session key from slash command', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(slashCommandMessage);
-    expect(channelId).toBe('G7W5W0000');
+    const sessionKey = connector.getUniqueSessionKey(slashCommandMessage);
+    expect(sessionKey).toBe('G7W5W0000');
   });
 
-  it('extract correct channel id from slash command', () => {
+  it("extract correct session key from view event's private_metadata", () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(slashCommandMessage);
-    expect(channelId).toBe('G7W5W0000');
+    const sessionKey = connector.getUniqueSessionKey(
+      viewSubmissionRequest.body
+    );
+    expect(sessionKey).toBe('C02ELGNBH');
   });
 
-  it("extract correct channel id from view event's private_metadata", () => {
+  // home tab
+  it('extract correct session key from appHomeOpenedOnMessagesTabRequest', () => {
     const { connector } = setup();
-    const channelId = connector.getUniqueSessionKey(viewSubmissionRequest.body);
-    expect(channelId).toBe('C02ELGNBH');
+    const sessionKey = connector.getUniqueSessionKey(
+      appHomeOpenedOnMessagesTabRequest
+    );
+    expect(sessionKey).toBe('DQMT00000');
+  });
+
+  it('extract correct session key from appHomeOpenedOnHomeTabRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      appHomeOpenedOnHomeTabRequest
+    );
+    expect(sessionKey).toBe('DQMT00000');
+  });
+
+  it('extract correct session key from blockActionsOnHomeTabRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      blockActionsOnHomeTabRequest
+    );
+    expect(sessionKey).toBe('U0HD00000');
   });
 });
 


### PR DESCRIPTION
# issue
When user clicked a button on home tab, session key can't generate correctly.

# spec
If the slack event is not related to any channel, then the session key set to the user id.