### PR TITLE
feat: export clients, factories from messaging-apis

### DIFF
--- a/packages/bottender/src/__tests__/index.spec.ts
+++ b/packages/bottender/src/__tests__/index.spec.ts
@@ -23,6 +23,15 @@ describe('core', () => {
     expect(core.ViberConnector).toBeDefined();
   });
 
+  it('export clients', () => {
+    expect(core.MessengerClient).toBeDefined();
+    expect(core.TwilioClient).toBeDefined();
+    expect(core.LineClient).toBeDefined();
+    expect(core.SlackOAuthClient).toBeDefined();
+    expect(core.TelegramClient).toBeDefined();
+    expect(core.ViberClient).toBeDefined();
+  });
+
   it('export cache implements', () => {
     expect(core.MemoryCacheStore).toBeDefined();
     expect(core.RedisCacheStore).toBeDefined();

--- a/packages/bottender/src/index.ts
+++ b/packages/bottender/src/index.ts
@@ -43,6 +43,11 @@ export { default as FacebookBaseConnector } from './messenger/FacebookBaseConnec
 export { default as MessengerConnector } from './messenger/MessengerConnector';
 export { default as MessengerContext } from './messenger/MessengerContext';
 export { default as MessengerEvent } from './messenger/MessengerEvent';
+export {
+  Messenger,
+  MessengerClient,
+  MessengerBatch,
+} from 'messaging-api-messenger';
 export { MessengerTypes };
 
 /* WhatsApp */
@@ -50,6 +55,7 @@ export { default as WhatsappBot } from './whatsapp/WhatsappBot';
 export { default as WhatsappConnector } from './whatsapp/WhatsappConnector';
 export { default as WhatsappContext } from './whatsapp/WhatsappContext';
 export { default as WhatsappEvent } from './whatsapp/WhatsappEvent';
+export { default as TwilioClient } from './whatsapp/TwilioClient';
 export { WhatsappTypes };
 
 /* LINE */
@@ -57,7 +63,7 @@ export { default as LineBot } from './line/LineBot';
 export { default as LineConnector } from './line/LineConnector';
 export { default as LineContext } from './line/LineContext';
 export { default as LineEvent } from './line/LineEvent';
-export { LineNotify } from 'messaging-api-line';
+export { Line, LineNotify, LineClient } from 'messaging-api-line';
 export { LineTypes };
 
 /* Slack */
@@ -65,6 +71,7 @@ export { default as SlackBot } from './slack/SlackBot';
 export { default as SlackConnector } from './slack/SlackConnector';
 export { default as SlackContext } from './slack/SlackContext';
 export { default as SlackEvent } from './slack/SlackEvent';
+export { SlackOAuthClient } from 'messaging-api-slack';
 export { SlackTypes };
 
 /* Telegram */
@@ -72,6 +79,7 @@ export { default as TelegramBot } from './telegram/TelegramBot';
 export { default as TelegramConnector } from './telegram/TelegramConnector';
 export { default as TelegramContext } from './telegram/TelegramContext';
 export { default as TelegramEvent } from './telegram/TelegramEvent';
+export { TelegramClient } from 'messaging-api-telegram';
 export { TelegramTypes };
 
 /* Viber */
@@ -79,6 +87,7 @@ export { default as ViberBot } from './viber/ViberBot';
 export { default as ViberConnector } from './viber/ViberConnector';
 export { default as ViberContext } from './viber/ViberContext';
 export { default as ViberEvent } from './viber/ViberEvent';
+export { ViberClient } from 'messaging-api-viber';
 export { ViberTypes };
 
 /* Types */


### PR DESCRIPTION
So we can easily use the same version clients in our bots and message push system. 