### PR TITLE
Fix context.views.open in slack home tab

### DIFF
--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -151,11 +151,6 @@ export default class SlackConnector
       return rawEvent.channelId;
     }
 
-    // For slack modal
-    if (rawEvent.view && rawEvent.view.privateMetadata) {
-      return JSON.parse(rawEvent.view.privateMetadata).channelId;
-    }
-
     // For reaction_added format
     if (
       rawEvent.item &&

--- a/packages/bottender/src/slack/SlackConnector.ts
+++ b/packages/bottender/src/slack/SlackConnector.ts
@@ -151,6 +151,14 @@ export default class SlackConnector
       return rawEvent.channelId;
     }
 
+    // For slack modal
+    if (rawEvent.view && rawEvent.view.privateMetadata) {
+      const channelId = JSON.parse(rawEvent.view.privateMetadata).channelId;
+      if (channelId) {
+        return channelId;
+      }
+    }
+
     // For reaction_added format
     if (
       rawEvent.item &&

--- a/packages/bottender/src/slack/SlackContext.ts
+++ b/packages/bottender/src/slack/SlackContext.ts
@@ -9,7 +9,7 @@ import Session from '../session/Session';
 import { RequestContext } from '../types';
 
 import SlackEvent from './SlackEvent';
-import { Message, UIEvent } from './SlackTypes';
+import { Message } from './SlackTypes';
 
 export type SlackContextOptions = {
   client: SlackOAuthClient;
@@ -345,16 +345,7 @@ export default class SlackContext extends Context<
    * https://api.slack.com/methods/views.open
    */
   _openView(options: SlackTypes.OpenViewOptions): Promise<any> {
-    return this._client.views.open({
-      ...options,
-      view: {
-        ...options.view,
-        privateMetadata: JSON.stringify({
-          original: options.view.privateMetadata,
-          channelId: (this._event.rawEvent as UIEvent).channel.id,
-        }),
-      },
-    });
+    return this._client.views.open(options);
   }
 
   /**

--- a/packages/bottender/src/slack/SlackContext.ts
+++ b/packages/bottender/src/slack/SlackContext.ts
@@ -9,7 +9,7 @@ import Session from '../session/Session';
 import { RequestContext } from '../types';
 
 import SlackEvent from './SlackEvent';
-import { Message } from './SlackTypes';
+import { Message, UIEvent } from './SlackTypes';
 
 export type SlackContextOptions = {
   client: SlackOAuthClient;
@@ -345,7 +345,16 @@ export default class SlackContext extends Context<
    * https://api.slack.com/methods/views.open
    */
   _openView(options: SlackTypes.OpenViewOptions): Promise<any> {
-    return this._client.views.open(options);
+    return this._client.views.open({
+      ...options,
+      view: {
+        ...options.view,
+        privateMetadata: JSON.stringify({
+          original: options.view.privateMetadata,
+          channelId: (this._event.rawEvent as UIEvent).channel?.id,
+        }),
+      },
+    });
   }
 
   /**

--- a/packages/bottender/src/slack/SlackTypes.ts
+++ b/packages/bottender/src/slack/SlackTypes.ts
@@ -76,7 +76,7 @@ export type UIEvent = {
     id: string;
     domain: string;
   };
-  channel: {
+  channel?: {
     id: string;
     name: string;
   };

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -259,6 +259,66 @@ const blockActionsOnHomeTabRequest = {
   ],
 };
 
+const viewClosedRequest = {
+  type: 'view_closed',
+  team: {
+    id: 'T0HD00000',
+    domain: 'etrexgroup',
+  },
+  user: {
+    id: 'U0HD00000',
+    username: 'etrexkuo',
+    name: 'etrexkuo',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'zqJtOkYeD6jkqEpZSzv4KLY2',
+  view: {
+    id: 'V015K400000',
+    teamId: 'T0HD00000',
+    type: 'modal',
+    blocks: [
+      {
+        type: 'actions',
+        blockId: '4AGRy',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'qq',
+            text: {
+              type: 'plain_text',
+              text: 'buton text',
+              emoji: true,
+            },
+          },
+        ],
+      },
+    ],
+    privateMetadata: '',
+    callbackId: '',
+    state: {
+      values: {},
+    },
+    hash: '1592381497.91f5a24e',
+    title: {
+      type: 'plain_text',
+      text: 'title',
+      emoji: true,
+    },
+    clearOnClose: false,
+    notifyOnClose: true,
+    close: null,
+    submit: null,
+    previousViewId: null,
+    rootViewId: 'V015K400000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  isCleared: true,
+};
+
 const RtmMessage = {
   type: 'message',
   channel: 'G7W5WAAAA',
@@ -369,12 +429,12 @@ describe('#getUniqueSessionKey', () => {
     expect(sessionKey).toBe('G7W5W0000');
   });
 
-  it("extract correct session key from view event's private_metadata", () => {
+  it('extract correct session key from viewSubmissionRequest', () => {
     const { connector } = setup();
     const sessionKey = connector.getUniqueSessionKey(
       viewSubmissionRequest.body
     );
-    expect(sessionKey).toBe('C02ELGNBH');
+    expect(sessionKey).toBe('UCL2D708M');
   });
 
   // home tab
@@ -399,6 +459,12 @@ describe('#getUniqueSessionKey', () => {
     const sessionKey = connector.getUniqueSessionKey(
       blockActionsOnHomeTabRequest
     );
+    expect(sessionKey).toBe('U0HD00000');
+  });
+
+  it('extract correct session key from viewClosedRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(viewClosedRequest);
     expect(sessionKey).toBe('U0HD00000');
   });
 });

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -97,47 +97,11 @@ const PinAddedRequest = {
 const interactiveMessageRequest = {
   body: {
     payload:
-      '{"type":"interactive_message","actions":[{"name":"game","type":"button","value":"chess"}],"callback_id":"wopr_game","team":{"id":"T056K3CM5","domain":"ricebug"},"channel":{"id":"D7WTL9ECE","name":"directmessage"},"user":{"id":"U056K3CN1","name":"tw0517tw"},"action_ts":"1511153911.446899","message_ts":"1511153905.000093","attachment_id":"1","token":"n8uIomPoBtc7fSnbHbQcmwdy","is_app_unfurl":false,"original_message":{"type":"message","user":"U7W1PH7MY","text":"Would you like to play a game?","bot_id":"B7VUVQTK5","attachments":[{"callback_id":"wopr_game","fallback":"You are unable to choose a game","text":"Choose a game to play","id":1,"color":"3AA3E3","actions":[{"id":"1","name":"game","text":"Chess","type":"button","value":"chess","style":""},{"id":"2","name":"game","text":"Falken\'s Maze","type":"button","value":"maze","style":""},{"id":"3","name":"game","text":"Thermonuclear War","type":"button","value":"war","style":"danger","confirm":{"text":"Wouldn\'t you prefer a good game of chess?","title":"Are you sure?","ok_text":"Yes","dismiss_text":"No"}}]}],"ts":"1511153905.000093"},"response_url":"https:\\/\\/hooks.slack.com\\/actions\\/T056K3CM5\\/274366307953\\/73rSfbP0LcVPWfAYB3GicEdD","trigger_id":"274927463524.5223114719.95a5b9f6d3b30dc7e07dec6bfa4610e5"}',
+      '{"type":"interactive_message","actions":[{"name":"game","type":"button","value":"chess"}],"callback_id":"wopr_game","team":{"id":"T056K3CM5","domain":"ricebug"},"channel":{"id":"D7WTL9ECE","name":"directmessage"},"user":{"id":"U056K3CN1","name":"tw0517tw"},"action_ts":"1511153911.446899","message_ts":"1511153905.000093","attachment_id":"1","token":"xxxxxxxxxxxxxxxxxxxxxxxx","is_app_unfurl":false,"original_message":{"type":"message","user":"U7W1PH7MY","text":"Would you like to play a game?","bot_id":"B7VUVQTK5","attachments":[{"callback_id":"wopr_game","fallback":"You are unable to choose a game","text":"Choose a game to play","id":1,"color":"3AA3E3","actions":[{"id":"1","name":"game","text":"Chess","type":"button","value":"chess","style":""},{"id":"2","name":"game","text":"Falken\'s Maze","type":"button","value":"maze","style":""},{"id":"3","name":"game","text":"Thermonuclear War","type":"button","value":"war","style":"danger","confirm":{"text":"Wouldn\'t you prefer a good game of chess?","title":"Are you sure?","ok_text":"Yes","dismiss_text":"No"}}]}],"ts":"1511153905.000093"},"response_url":"https:\\/\\/hooks.slack.com\\/actions\\/T056K3CM5\\/274366307953\\/73rSfbP0LcVPWfAYB3GicEdD","trigger_id":"274927463524.5223114719.95a5b9f6d3b30dc7e07dec6bfa4610e5"}',
   },
 };
 
-const viewSubmissionRequest = {
-  body: {
-    type: 'view_submission',
-    team: { id: 'T02RUPSBS', domain: 'yoctolinfo' },
-    user: {
-      id: 'UCL2D708M',
-      username: 'darkbtf',
-      name: 'darkbtf',
-      teamId: 'T02RUPSBS',
-    },
-    apiAppId: 'A604E7GSJ',
-    token: 'zBoHd4fjrvVcVuN9yTmlHMKC',
-    triggerId: '873508362498.2878808400.763026ca2acb11b3dfbcb85836d1c3d8',
-    view: {
-      id: 'VRQQ7JA4T',
-      teamId: 'T02RUPSBS',
-      type: 'modal',
-      blocks: [[Object]],
-      privateMetadata: '{"channelId":"C02ELGNBH"}',
-      callbackId: '截止',
-      state: { values: {} },
-      hash: '1577340522.d58ea69f',
-      title: { type: 'plain_text', text: '確認截止？', emoji: true },
-      clearOnClose: false,
-      notifyOnClose: false,
-      close: { type: 'plain_text', text: '取消', emoji: true },
-      submit: { type: 'plain_text', text: '送出 :boom:', emoji: true },
-      previousViewId: null,
-      rootViewId: 'VRQQ7JA4T',
-      appId: 'A604E7GSJ',
-      externalId: '',
-      appInstalledTeamId: 'T02RUPSBS',
-      botId: 'B618CBATV',
-    },
-  },
-};
-
+// Home
 const appHomeOpenedOnMessagesTabRequest = {
   type: 'app_home_opened',
   user: 'U0HD00000',
@@ -227,7 +191,7 @@ const blockActionsOnHomeTabRequest = {
         ],
       },
     ],
-    privateMetadata: '',
+    privateMetadata: '{}',
     callbackId: '',
     state: { values: {} },
     hash: '1592278912.3f2f9db2',
@@ -259,47 +223,239 @@ const blockActionsOnHomeTabRequest = {
   ],
 };
 
-const viewClosedRequest = {
-  type: 'view_closed',
-  team: {
-    id: 'T0HD00000',
-    domain: 'etrexgroup',
-  },
+// Home Modal
+const blockActionsOnHomeModalRequest = {
+  type: 'block_actions',
   user: {
     id: 'U0HD00000',
-    username: 'etrexkuo',
-    name: 'etrexkuo',
+    username: 'username',
+    name: 'name',
     teamId: 'T0HD00000',
   },
   apiAppId: 'AQ8600000',
-  token: 'zqJtOkYeD6jkqEpZSzv4KLY2',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  container: {
+    type: 'view',
+    viewId: 'V015LD00000',
+  },
+  triggerId: '1215686778640.17443231012.3a6962eea96e7dac6d2f1a907af6211e',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
   view: {
-    id: 'V015K400000',
+    id: 'V015LD00000',
     teamId: 'T0HD00000',
     type: 'modal',
     blocks: [
       {
+        type: 'context',
+        blockId: '2C4D9',
+        elements: [
+          {
+            type: 'plain_text',
+            text: 'text',
+            emoji: true,
+          },
+        ],
+      },
+      {
         type: 'actions',
-        blockId: '4AGRy',
+        blockId: 'DyE',
         elements: [
           {
             type: 'button',
-            actionId: 'qq',
+            actionId: 'xQkxX',
             text: {
               type: 'plain_text',
-              text: 'buton text',
+              text: 'button text',
               emoji: true,
             },
+            value: 'button value',
           },
         ],
       },
     ],
-    privateMetadata: '',
+    privateMetadata: '{}',
     callbackId: '',
     state: {
       values: {},
     },
-    hash: '1592381497.91f5a24e',
+    hash: '1592476707.898fb949',
+    title: {
+      type: 'plain_text',
+      text: 'title',
+      emoji: true,
+    },
+    clearOnClose: false,
+    notifyOnClose: false,
+    close: {
+      type: 'plain_text',
+      text: 'close',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'submit',
+      emoji: true,
+    },
+    previousViewId: null,
+    rootViewId: 'V015LD00000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  actions: [
+    {
+      actionId: 'xQkxX',
+      blockId: 'DyE',
+      text: {
+        type: 'plain_text',
+        text: 'button text',
+        emoji: true,
+      },
+      value: 'button value',
+      type: 'button',
+      actionTs: '1592476752.557160',
+    },
+  ],
+};
+
+const viewSubmissionOnHomeModalRequest = {
+  type: 'view_submission',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  triggerId: '1204566923633.17443231012.da8c753637a7f27e40991411664d77a2',
+  view: {
+    id: 'V015N200000',
+    teamId: 'T0HD00000',
+    type: 'modal',
+    blocks: [
+      {
+        type: 'context',
+        blockId: 'Umz',
+        elements: [
+          {
+            type: 'plain_text',
+            text: 'text',
+            emoji: true,
+          },
+        ],
+      },
+      {
+        type: 'actions',
+        blockId: 'Sk7k8',
+        elements: [
+          {
+            type: 'button',
+            actionId: '0L7ew',
+            text: {
+              type: 'plain_text',
+              text: 'button text',
+              emoji: true,
+            },
+            value: 'button value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '{}',
+    callbackId: '',
+    state: {
+      values: {},
+    },
+    hash: '1592477178.60ca56c9',
+    title: {
+      type: 'plain_text',
+      text: 'title',
+      emoji: true,
+    },
+    clearOnClose: false,
+    notifyOnClose: false,
+    close: {
+      type: 'plain_text',
+      text: 'close',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'submit',
+      emoji: true,
+    },
+    previousViewId: null,
+    rootViewId: 'V015N200000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  responseUrls: [],
+};
+
+const viewCloseOnHomeModalRequest = {
+  type: 'view_closed',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  view: {
+    id: 'V0157600000',
+    teamId: 'T0HD00000',
+    type: 'modal',
+    blocks: [
+      {
+        type: 'context',
+        blockId: 'WC8',
+        elements: [
+          {
+            type: 'plain_text',
+            text: 'text',
+            emoji: true,
+          },
+        ],
+      },
+      {
+        type: 'actions',
+        blockId: 'ZbPy',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'muR',
+            text: {
+              type: 'plain_text',
+              text: 'button text',
+              emoji: true,
+            },
+            value: 'button value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '{}',
+    callbackId: '',
+    state: {
+      values: {},
+    },
+    hash: '1592480265.1283b0b7',
     title: {
       type: 'plain_text',
       text: 'title',
@@ -307,16 +463,354 @@ const viewClosedRequest = {
     },
     clearOnClose: false,
     notifyOnClose: true,
-    close: null,
-    submit: null,
+    close: {
+      type: 'plain_text',
+      text: 'close',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'submit',
+      emoji: true,
+    },
     previousViewId: null,
-    rootViewId: 'V015K400000',
+    rootViewId: 'V0157600000',
     appId: 'AQ8600000',
     externalId: '',
     appInstalledTeamId: 'T0HD00000',
     botId: 'BQMT00000',
   },
   isCleared: true,
+};
+
+// Channel
+const blockActionsOnChannelRequest = {
+  type: 'block_actions',
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  container: {
+    type: 'message',
+    messageTs: '1592454263.013800',
+    channelId: 'DQMT00000',
+    isEphemeral: false,
+  },
+  triggerId: '1215785565232.17443231012.2e89dfa2540e010b618894ff8d2de08f',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
+  channel: {
+    id: 'DQMT00000',
+    name: 'directmessage',
+  },
+  message: {
+    botId: 'BQMT00000',
+    type: 'message',
+    text: "This content can't be displayed.",
+    user: 'UQKL00000',
+    ts: '1592454263.013800',
+    team: 'T0HD00000',
+    blocks: [
+      {
+        type: 'actions',
+        blockId: 'nxyEU',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'bdj',
+            text: {
+              type: 'plain_text',
+              text: 'button text',
+              emoji: true,
+            },
+            value: 'button value',
+          },
+        ],
+      },
+    ],
+  },
+  responseUrl:
+    'https://hooks.slack.com/actions/T0HD00000/1190570555349/zCOfyY2sBayE3Amaj1GgXUtW',
+  actions: [
+    {
+      actionId: 'bdj',
+      blockId: 'nxyEU',
+      text: {
+        type: 'plain_text',
+        text: 'button text',
+        emoji: true,
+      },
+      value: 'button value',
+      type: 'button',
+      actionTs: '1592480315.455021',
+    },
+  ],
+};
+
+// Channel Modal
+const blockActionsOnChannelModalRequest = {
+  type: 'block_actions',
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  container: {
+    type: 'view',
+    viewId: 'V016BP00000',
+  },
+  triggerId: '1204575603665.17443231012.ccdd4f2d4b840eb48c451235f6b0a84c',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
+  view: {
+    id: 'V016BP00000',
+    teamId: 'T0HD00000',
+    type: 'modal',
+    blocks: [
+      {
+        type: 'context',
+        blockId: 'ikxi3',
+        elements: [
+          {
+            type: 'plain_text',
+            text: '佳甯 郭 已經幫你打卡囉！ 2020/06/18 19:38 button text',
+            emoji: true,
+          },
+        ],
+      },
+      {
+        type: 'actions',
+        blockId: 'HWc',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'c3pJ',
+            text: {
+              type: 'plain_text',
+              text: 'button text',
+              emoji: true,
+            },
+            value: 'button value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '{"channelId":"DQMT00000"}',
+    callbackId: '',
+    state: {
+      values: {},
+    },
+    hash: '1592480318.25f7311a',
+    title: {
+      type: 'plain_text',
+      text: 'title',
+      emoji: true,
+    },
+    clearOnClose: false,
+    notifyOnClose: true,
+    close: {
+      type: 'plain_text',
+      text: 'close',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'submit',
+      emoji: true,
+    },
+    previousViewId: null,
+    rootViewId: 'V016BP00000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  actions: [
+    {
+      actionId: 'c3pJ',
+      blockId: 'HWc',
+      text: {
+        type: 'plain_text',
+        text: 'button text',
+        emoji: true,
+      },
+      value: 'button value',
+      type: 'button',
+      actionTs: '1592480408.122391',
+    },
+  ],
+};
+
+const viewSubmissionOnChannelModalRequest = {
+  type: 'view_submission',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  triggerId: '1215789028880.17443231012.f9236c7807d6bdace1e7809e346b8e6c',
+  view: {
+    id: 'V016BP00000',
+    teamId: 'T0HD00000',
+    type: 'modal',
+    blocks: [
+      {
+        type: 'context',
+        blockId: 'ikxi3',
+        elements: [
+          {
+            type: 'plain_text',
+            text: 'text',
+            emoji: true,
+          },
+        ],
+      },
+      {
+        type: 'actions',
+        blockId: 'HWc',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'c3pJ',
+            text: {
+              type: 'plain_text',
+              text: 'button text',
+              emoji: true,
+            },
+            value: 'button value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '{"channelId":"DQMT00000"}',
+    callbackId: '',
+    state: {
+      values: {},
+    },
+    hash: '1592480318.25f7311a',
+    title: {
+      type: 'plain_text',
+      text: 'title',
+      emoji: true,
+    },
+    clearOnClose: false,
+    notifyOnClose: true,
+    close: {
+      type: 'plain_text',
+      text: 'close',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'submit',
+      emoji: true,
+    },
+    previousViewId: null,
+    rootViewId: 'V016BP00000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  responseUrls: [],
+};
+
+const viewCloseOnChannelModalRequest = {
+  type: 'view_closed',
+  team: {
+    id: 'T0HD00000',
+    domain: 'domain',
+  },
+  user: {
+    id: 'U0HD00000',
+    username: 'username',
+    name: 'name',
+    teamId: 'T0HD00000',
+  },
+  apiAppId: 'AQ8600000',
+  token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+  view: {
+    id: 'V015LG00000',
+    teamId: 'T0HD00000',
+    type: 'modal',
+    blocks: [
+      {
+        type: 'context',
+        blockId: 'AQaXQ',
+        elements: [
+          {
+            type: 'plain_text',
+            text: '佳甯 郭 已經幫你打卡囉！ 2020/06/18 19:41 button text',
+            emoji: true,
+          },
+        ],
+      },
+      {
+        type: 'actions',
+        blockId: 'QUo',
+        elements: [
+          {
+            type: 'button',
+            actionId: 'E2G9D',
+            text: {
+              type: 'plain_text',
+              text: 'button text',
+              emoji: true,
+            },
+            value: 'button value',
+          },
+        ],
+      },
+    ],
+    privateMetadata: '{"channelId":"DQMT00000"}',
+    callbackId: '',
+    state: {
+      values: {},
+    },
+    hash: '1592480467.1addf637',
+    title: {
+      type: 'plain_text',
+      text: 'title',
+      emoji: true,
+    },
+    clearOnClose: false,
+    notifyOnClose: true,
+    close: {
+      type: 'plain_text',
+      text: 'close',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'submit',
+      emoji: true,
+    },
+    previousViewId: null,
+    rootViewId: 'V015LG00000',
+    appId: 'AQ8600000',
+    externalId: '',
+    appInstalledTeamId: 'T0HD00000',
+    botId: 'BQMT00000',
+  },
+  isCleared: false,
 };
 
 const RtmMessage = {
@@ -429,14 +923,6 @@ describe('#getUniqueSessionKey', () => {
     expect(sessionKey).toBe('G7W5W0000');
   });
 
-  it('extract correct session key from viewSubmissionRequest', () => {
-    const { connector } = setup();
-    const sessionKey = connector.getUniqueSessionKey(
-      viewSubmissionRequest.body
-    );
-    expect(sessionKey).toBe('UCL2D708M');
-  });
-
   // home tab
   it('extract correct session key from appHomeOpenedOnMessagesTabRequest', () => {
     const { connector } = setup();
@@ -462,10 +948,63 @@ describe('#getUniqueSessionKey', () => {
     expect(sessionKey).toBe('U0HD00000');
   });
 
-  it('extract correct session key from viewClosedRequest', () => {
+  // home modal
+  it('extract correct session key from blockActionsOnHomeModalRequest', () => {
     const { connector } = setup();
-    const sessionKey = connector.getUniqueSessionKey(viewClosedRequest);
+    const sessionKey = connector.getUniqueSessionKey(
+      blockActionsOnHomeModalRequest
+    );
     expect(sessionKey).toBe('U0HD00000');
+  });
+
+  it('extract correct session key from viewSubmissionOnHomeModalRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      viewSubmissionOnHomeModalRequest
+    );
+    expect(sessionKey).toBe('U0HD00000');
+  });
+
+  it('extract correct session key from viewCloseOnHomeModalRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      viewCloseOnHomeModalRequest
+    );
+    expect(sessionKey).toBe('U0HD00000');
+  });
+
+  // channel
+  it('extract correct session key from blockActionsOnChannelRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      blockActionsOnChannelRequest
+    );
+    expect(sessionKey).toBe('DQMT00000');
+  });
+
+  // channel modal
+  it('extract correct session key from blockActionsOnChannelModalRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      blockActionsOnChannelModalRequest
+    );
+    expect(sessionKey).toBe('DQMT00000');
+  });
+
+  it('extract correct session key from viewSubmissionOnChannelModalRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      viewSubmissionOnChannelModalRequest
+    );
+    expect(sessionKey).toBe('DQMT00000');
+  });
+
+  it('extract correct session key from viewCloseOnChannelModalRequest', () => {
+    const { connector } = setup();
+    const sessionKey = connector.getUniqueSessionKey(
+      viewCloseOnChannelModalRequest
+    );
+    expect(sessionKey).toBe('DQMT00000');
   });
 });
 

--- a/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackConnector.spec.ts
@@ -584,7 +584,7 @@ const blockActionsOnChannelModalRequest = {
         elements: [
           {
             type: 'plain_text',
-            text: '佳甯 郭 已經幫你打卡囉！ 2020/06/18 19:38 button text',
+            text: 'button text',
             emoji: true,
           },
         ],
@@ -758,7 +758,7 @@ const viewCloseOnChannelModalRequest = {
         elements: [
           {
             type: 'plain_text',
-            text: '佳甯 郭 已經幫你打卡囉！ 2020/06/18 19:41 button text',
+            text: 'button text',
             emoji: true,
           },
         ],

--- a/packages/bottender/src/slack/__tests__/SlackContext.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackContext.spec.ts
@@ -464,10 +464,7 @@ describe('#views.open', () => {
 
     expect(client.views.open).toBeCalledWith({
       triggerId: '12345.98765.abcd2358fdea',
-      view: {
-        ...VIEW_PAYLOAD,
-        privateMetadata: '{"original":"Shh it is a secret"}',
-      },
+      view: VIEW_PAYLOAD,
     });
   });
 });

--- a/packages/bottender/src/slack/__tests__/SlackContext.spec.ts
+++ b/packages/bottender/src/slack/__tests__/SlackContext.spec.ts
@@ -464,7 +464,10 @@ describe('#views.open', () => {
 
     expect(client.views.open).toBeCalledWith({
       triggerId: '12345.98765.abcd2358fdea',
-      view: VIEW_PAYLOAD,
+      view: {
+        ...VIEW_PAYLOAD,
+        privateMetadata: '{"original":"Shh it is a secret"}',
+      },
     });
   });
 });


### PR DESCRIPTION
# previous implement
- Set channelId to view.privateMetadata to store the session key in the view.
- If a webhook event from button clicked on a modal, get sessionKey from view.privateMetadata.

# current implement
- Get sessionKey from channelId or userId.
-  If a webhook event from button clicked on a channel modal, get sessionKey from view.privateMetadata.
-  If a webhook event from button clicked on a home modal, get sessionKey from user id.