### PR TITLE
deps(bottender-facebook): remove messaging-api-messenger, import from bottender instead

### DIFF
--- a/packages/bottender-facebook/package.json
+++ b/packages/bottender-facebook/package.json
@@ -19,11 +19,9 @@
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "bottender": ">= 1.5.0-alpha.13",
-    "messaging-api-messenger": ">= 1.0.0-beta.26"
+    "bottender": ">= 1.5.1-alpha.1"
   },
   "devDependencies": {
-    "bottender": "^1.5.1-alpha.1",
-    "messaging-api-messenger": "^1.0.0-beta.26"
+    "bottender": "^1.5.1-alpha.1"
   }
 }

--- a/packages/bottender-facebook/src/FacebookBatch.ts
+++ b/packages/bottender-facebook/src/FacebookBatch.ts
@@ -1,6 +1,6 @@
 import querystring from 'querystring';
 
-import { MessengerTypes } from 'messaging-api-messenger';
+import { MessengerTypes } from 'bottender';
 
 import * as Types from './FacebookTypes';
 

--- a/packages/bottender-facebook/src/FacebookClient.ts
+++ b/packages/bottender-facebook/src/FacebookClient.ts
@@ -1,6 +1,6 @@
 import AxiosError from 'axios-error';
 import get from 'lodash/get';
-import { MessengerClient, MessengerTypes } from 'messaging-api-messenger';
+import { MessengerClient, MessengerTypes } from 'bottender';
 
 import * as Types from './FacebookTypes';
 

--- a/packages/bottender-facebook/src/FacebookContext.ts
+++ b/packages/bottender-facebook/src/FacebookContext.ts
@@ -1,8 +1,12 @@
 import { EventEmitter } from 'events';
 
 import warning from 'warning';
-import { Context, MessengerTypes, RequestContext } from 'bottender';
-import { MessengerBatch } from 'messaging-api-messenger';
+import {
+  Context,
+  MessengerBatch,
+  MessengerTypes,
+  RequestContext,
+} from 'bottender';
 import { MessengerBatchQueue } from 'messenger-batch';
 
 import FacebookBatch from './FacebookBatch';


### PR DESCRIPTION
It's more reliable if we're using the same version `messaging-api-messenger` here. 