### PR TITLE
fix: commentId on FeedReaction type

### DIFF
--- a/packages/bottender-facebook/src/FacebookTypes.ts
+++ b/packages/bottender-facebook/src/FacebookTypes.ts
@@ -105,7 +105,7 @@ export type FeedReaction = {
     id: string;
   };
   parentId: string;
-  commentId: string;
+  commentId?: string;
   postId: string;
   verb: 'add' | 'edit' | 'remove';
   item: 'reaction';


### PR DESCRIPTION
The reactions on the post do not have the comment_id so the commentId here should be optional