### PR TITLE
feat(express): support url behind proxies

### DIFF
--- a/examples/custom-server-express/server.js
+++ b/examples/custom-server-express/server.js
@@ -13,6 +13,10 @@ const handle = app.getRequestHandler();
 app.prepare().then(() => {
   const server = express();
 
+  // If your express server is behind a proxy, you need to call `enable('trust proxy')`
+  // See: http://expressjs.com/en/guide/behind-proxies.html#express-behind-proxies
+  // server.enable('trust proxy');
+
   const verify = (req, _, buf) => {
     req.rawBody = buf.toString();
   };

--- a/packages/bottender/src/server/Server.ts
+++ b/packages/bottender/src/server/Server.ts
@@ -121,9 +121,14 @@ class Server {
       return;
     }
 
-    const { pathname, searchParams } = new url.URL(
-      `https://${req.headers.host}${req.url}`
-    );
+    // TODO: add proxy support in Bottender to apply X-Forwarded-Host and X-Forwarded-Proto
+    // conditionally instead of replying on express.
+    const hostname = (req as any).hostname || req.headers.host;
+    const protocol = (req as any).protocol || 'https';
+
+    const requestUrl = `${protocol}://${hostname}${req.url}`;
+
+    const { pathname, searchParams } = new url.URL(requestUrl);
 
     const query = fromEntries(searchParams.entries());
 
@@ -133,7 +138,7 @@ class Server {
       if (pathname === webhookPath) {
         const result = (bot.connector as any).preprocess({
           method: req.method,
-          url: `https://${req.headers.host}${req.url}`,
+          url: requestUrl,
           headers: req.headers,
           query,
           rawBody: (req as any).rawBody,


### PR DESCRIPTION
#815

This is a quick workaround for supporting express behind proxies, but eventually we should add proxy support in Bottender v1.5 to apply `X-Forwarded-Host` and `X-Forwarded-Proto` conditionally instead of replying on express. After that, we can gracefully support it even in koa, restify, ...etc.

