### PR TITLE
fix(MongoSessionStore): enable useUnifiedTopology to avoid warning

### DIFF
--- a/packages/bottender/src/session/MongoSessionStore.ts
+++ b/packages/bottender/src/session/MongoSessionStore.ts
@@ -34,7 +34,9 @@ export default class MongoSessionStore implements SessionStore {
   }
 
   async init(): Promise<MongoSessionStore> {
-    this._connection = (await MongoClient.connect(this._url)).db();
+    this._connection = (
+      await MongoClient.connect(this._url, { useUnifiedTopology: true })
+    ).db();
 
     return this;
   }

--- a/packages/bottender/src/session/__tests__/MongoSessionStore.spec.ts
+++ b/packages/bottender/src/session/__tests__/MongoSessionStore.spec.ts
@@ -56,14 +56,9 @@ describe('#init', () => {
     const { store } = setup();
 
     await store.init();
-    expect(MongoClient.connect).toBeCalledWith('mongodb://fakemongourl');
-  });
-
-  it('should connect to provided url', async () => {
-    const { store } = setup();
-
-    await store.init();
-    expect(MongoClient.connect).toBeCalledWith('mongodb://fakemongourl');
+    expect(MongoClient.connect).toBeCalledWith('mongodb://fakemongourl', {
+      useUnifiedTopology: true,
+    });
   });
 });
 


### PR DESCRIPTION
Add `{ useUnifiedTopology: true }` to avoid breaking in the future. Fix #830.

See: https://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html#.connect