### PR TITLE
[Bug Fix] Index.d.ts not being generated for @bottender/dialogflow

### DIFF
--- a/packages/bottender-dialogflow/src/index.ts
+++ b/packages/bottender-dialogflow/src/index.ts
@@ -30,7 +30,7 @@ function getFulfillments(fulfillmentMessages: Message[]): string[] {
  *   },
  * });
  */
-module.exports = function dialogflow({
+export default function dialogflow({
   projectId,
   languageCode = 'en',
   actions = {},


### PR DESCRIPTION
**What does this do?**

Fixes a bug wherein `index.d.ts` was not being generated properly.

**Notes**

I have not bumped the version and/or updated the `CHANGELOG` file.
If that is required from my end. Please do let me know.

