### PR TITLE
fix: add validate function for platform checkbox in create-bottender-app

### DIFF
--- a/packages/create-bottender-app/src/index.ts
+++ b/packages/create-bottender-app/src/index.ts
@@ -75,6 +75,13 @@ const getQuestions = (): Record<string, any>[] => [
     message: 'What platform of bot do you want to create?',
     type: 'checkbox',
     choices: ['messenger', 'whatsapp', 'line', 'slack', 'telegram', 'viber'],
+    validate: (value: string[]) => {
+      if (value.length < 1) {
+        return 'Should select at least one platform';
+      }
+
+      return true;
+    },
   },
   {
     name: 'session',


### PR DESCRIPTION
As #887 stated, if no platform selected, will cause an error generating the code.

So I add the validate function for the platform inquirer question checkbox.