### PR TITLE
multiple bots for channel

### DIFF
--- a/packages/bottender/src/getClient.ts
+++ b/packages/bottender/src/getClient.ts
@@ -50,7 +50,7 @@ function getClient<C extends string>(
     );
   }
 
-  const ChannelBot = BOT_MAP[channel as Channel];
+  const ChannelBot = BOT_MAP[channel.split('_')[0] as Channel];
 
   const channelBot = new ChannelBot({
     ...channelConfig,

--- a/packages/bottender/src/initializeServer.ts
+++ b/packages/bottender/src/initializeServer.ts
@@ -80,7 +80,7 @@ function initializeServer({
     Object.entries(channels || {})
       .filter(([, { enabled }]) => enabled)
       .map(([channel, { path: webhookPath, ...channelConfig }]) => {
-        const ChannelBot = BOT_MAP[channel as Channel];
+        const ChannelBot = BOT_MAP[channel.split('_')[0] as Channel];
         const channelBot = new ChannelBot({
           ...channelConfig,
           sessionStore,

--- a/packages/bottender/src/server/Server.ts
+++ b/packages/bottender/src/server/Server.ts
@@ -91,8 +91,9 @@ class Server {
       .filter(([, { enabled }]) => enabled)
       .map(([channel, { path: webhookPath, ...channelConfig }]) => {
         // eslint-disable-next-line import/no-dynamic-require
-        const ChannelBot = require(`../${channel}/${pascalcase(channel)}Bot`)
-          .default;
+        const ChannelBot = require(`../${channel.split('_')[0]}/${pascalcase(
+          channel.split('_')[0]
+        )}Bot`).default;
         const channelBot = new ChannelBot({
           ...channelConfig,
           sessionStore,


### PR DESCRIPTION
With this PR I want to draw your attention to the problem [Multiple bots support in telegram or viber #920](https://github.com/Yoctol/bottender/issues/920#issue-976685680) With this configuration, the application can process messages from multiple bots on the same channel. Of course, this is not a very elegant solution. I think that this problem can be solved in a different way, especially since release 1.5. But at this stage, it is very important for me to know your opinion on the support of multiple bots for the channel. Will it be implemented in the original project or do I need to do it in a fork?