### PR TITLE
chore(LineContext): add deprecated warning to some methods

### DIFF
--- a/packages/bottender/src/line/LineContext.ts
+++ b/packages/bottender/src/line/LineContext.ts
@@ -76,6 +76,7 @@ class LineContext extends Context<LineClient, LineEvent> {
   /**
    * Inject access token for the context.
    *
+   * @deprecated No longer recommended.
    */
   useAccessToken(accessToken: string): void {
     warning(false, '`useAccessToken` is deprecated.');
@@ -470,11 +471,18 @@ class LineContext extends Context<LineClient, LineEvent> {
     return this.reply([Line.createTemplate(altText, template, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   replyButtonTemplate(
     altText: string,
     buttonTemplate: Omit<LineTypes.ButtonsTemplate, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.replyButtonTemplate()` is deprecated. Use `context.replyButtonsTemplate()` instead.'
+    );
     return this.reply([
       Line.createButtonTemplate(altText, buttonTemplate, options),
     ]);
@@ -519,7 +527,14 @@ class LineContext extends Context<LineClient, LineEvent> {
     ]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   push(messages: LineTypes.Message[]) {
+    warning(
+      false,
+      '`context.push()` is deprecated. Use `context.client.push()` instead.'
+    );
     if (!this._session) {
       warning(false, `push: should not be called in context without session`);
       return;
@@ -534,13 +549,23 @@ class LineContext extends Context<LineClient, LineEvent> {
     return this._client.push(this._session[sessionType].id, messages);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushText(
     text: string,
     options?: LineTypes.MessageOptions & { emojis?: LineTypes.Emoji[] }
   ) {
+    warning(
+      false,
+      '`context.pushText()` is deprecated. Use `context.client.pushText()` instead.'
+    );
     return this.push([Line.createText(text, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushImage(
     image: {
       originalContentUrl: string;
@@ -548,9 +573,16 @@ class LineContext extends Context<LineClient, LineEvent> {
     },
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushImage()` is deprecated. Use `context.client.pushImage()` instead.'
+    );
     return this.push([Line.createImage(image, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushVideo(
     video: {
       originalContentUrl: string;
@@ -558,9 +590,16 @@ class LineContext extends Context<LineClient, LineEvent> {
     },
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushVideo()` is deprecated. Use `context.client.pushVideo()` instead.'
+    );
     return this.push([Line.createVideo(video, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushAudio(
     audio: {
       originalContentUrl: string;
@@ -568,75 +607,138 @@ class LineContext extends Context<LineClient, LineEvent> {
     },
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushAudio()` is deprecated. Use `context.client.pushAudio()` instead.'
+    );
     return this.push([Line.createAudio(audio, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushLocation(
     location: LineTypes.Location,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushLocation()` is deprecated. Use `context.client.pushLocation()` instead.'
+    );
     return this.push([Line.createLocation(location, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushSticker(
     sticker: Omit<LineTypes.StickerMessage, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushSticker()` is deprecated. Use `context.client.pushSticker()` instead.'
+    );
     return this.push([Line.createSticker(sticker, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushImagemap(
     altText: string,
     imagemap: Omit<LineTypes.ImagemapMessage, 'type' | 'altText'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushImagemap()` is deprecated. Use `context.client.pushImagemap()` instead.'
+    );
     return this.push([Line.createImagemap(altText, imagemap, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushFlex(
     altText: string,
     flex: LineTypes.FlexContainer,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushFlex()` is deprecated. Use `context.client.pushFlex()` instead.'
+    );
     return this.push([Line.createFlex(altText, flex, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushTemplate(
     altText: string,
     template: LineTypes.Template,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushTemplate()` is deprecated. Use `context.client.pushTemplate()` instead.'
+    );
     return this.push([Line.createTemplate(altText, template, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushButtonTemplate(
     altText: string,
     buttonTemplate: Omit<LineTypes.ButtonsTemplate, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushButtonTemplate()` is deprecated. Use `context.client.pushButtonTemplate()` instead.'
+    );
     return this.push([
       Line.createButtonTemplate(altText, buttonTemplate, options),
     ]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushButtonsTemplate(
     altText: string,
     buttonTemplate: Omit<LineTypes.ButtonsTemplate, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushButtonsTemplate()` is deprecated. Use `context.client.pushButtonsTemplate()` instead.'
+    );
     return this.pushButtonTemplate(altText, buttonTemplate, options);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushConfirmTemplate(
     altText: string,
     confirmTemplate: Omit<LineTypes.ConfirmTemplate, 'type'>,
     options: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushConfirmTemplate()` is deprecated. Use `context.client.pushConfirmTemplate()` instead.'
+    );
     return this.push([
       Line.createConfirmTemplate(altText, confirmTemplate, options),
     ]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushCarouselTemplate(
     altText: string,
     columns: LineTypes.ColumnObject[],
@@ -645,20 +747,38 @@ class LineContext extends Context<LineClient, LineEvent> {
       imageSize?: 'cover' | 'contain';
     } & LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushCarouselTemplate()` is deprecated. Use `context.client.pushCarouselTemplate()` instead.'
+    );
     return this.push([Line.createCarouselTemplate(altText, columns, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   pushImageCarouselTemplate(
     altText: string,
     columns: LineTypes.ImageCarouselColumnObject[],
     options: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.pushImageCarouselTemplate()` is deprecated. Use `context.client.pushImageCarouselTemplate()` instead.'
+    );
     return this.push([
       Line.createImageCarouselTemplate(altText, columns, options),
     ]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   send(messages: LineTypes.Message[]) {
+    warning(
+      false,
+      '`context.send()` is deprecated. Use `context.reply()` instead.'
+    );
     if (this._sendMethod === 'push') {
       return this.push(messages);
     }
@@ -672,6 +792,9 @@ class LineContext extends Context<LineClient, LineEvent> {
     return this.send([Line.createText(text, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendImage(
     image: {
       originalContentUrl: string;
@@ -679,9 +802,16 @@ class LineContext extends Context<LineClient, LineEvent> {
     },
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendImage()` is deprecated. Use `context.replyImage()` instead.'
+    );
     return this.send([Line.createImage(image, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendVideo(
     video: {
       originalContentUrl: string;
@@ -689,9 +819,16 @@ class LineContext extends Context<LineClient, LineEvent> {
     },
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendVideo()` is deprecated. Use `context.replyVideo()` instead.'
+    );
     return this.send([Line.createVideo(video, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendAudio(
     audio: {
       originalContentUrl: string;
@@ -699,75 +836,138 @@ class LineContext extends Context<LineClient, LineEvent> {
     },
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendAudio()` is deprecated. Use `context.replyAudio()` instead.'
+    );
     return this.send([Line.createAudio(audio, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendLocation(
     location: LineTypes.Location,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendLocation()` is deprecated. Use `context.replyLocation()` instead.'
+    );
     return this.send([Line.createLocation(location, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendSticker(
     sticker: Omit<LineTypes.StickerMessage, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendSticker()` is deprecated. Use `context.replySticker()` instead.'
+    );
     return this.send([Line.createSticker(sticker, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendImagemap(
     altText: string,
     imagemap: Omit<LineTypes.ImagemapMessage, 'type' | 'altText'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendImagemap()` is deprecated. Use `context.replyImagemap()` instead.'
+    );
     return this.send([Line.createImagemap(altText, imagemap, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendFlex(
     altText: string,
     flex: LineTypes.FlexContainer,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendFlex()` is deprecated. Use `context.replyFlex()` instead.'
+    );
     return this.send([Line.createFlex(altText, flex, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendTemplate(
     altText: string,
     template: LineTypes.Template,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendTemplate()` is deprecated. Use `context.replyTemplate()` instead.'
+    );
     return this.send([Line.createTemplate(altText, template, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendButtonTemplate(
     altText: string,
     buttonTemplate: Omit<LineTypes.ButtonsTemplate, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendButtonTemplate()` is deprecated. Use `context.replyButtonsTemplate()` instead.'
+    );
     return this.send([
       Line.createButtonTemplate(altText, buttonTemplate, options),
     ]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendButtonsTemplate(
     altText: string,
     buttonTemplate: Omit<LineTypes.ButtonsTemplate, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendButtonsTemplate()` is deprecated. Use `context.replyButtonsTemplate()` instead.'
+    );
     return this.sendButtonTemplate(altText, buttonTemplate, options);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendConfirmTemplate(
     altText: string,
     confirmTemplate: Omit<LineTypes.ConfirmTemplate, 'type'>,
     options?: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendConfirmTemplate()` is deprecated. Use `context.replyConfirmTemplate()` instead.'
+    );
     return this.send([
       Line.createConfirmTemplate(altText, confirmTemplate, options),
     ]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendCarouselTemplate(
     altText: string,
     columns: LineTypes.ColumnObject[],
@@ -776,14 +976,25 @@ class LineContext extends Context<LineClient, LineEvent> {
       imageSize?: 'cover' | 'contain';
     } & LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendCarouselTemplate()` is deprecated. Use `context.replyCarouselTemplate()` instead.'
+    );
     return this.send([Line.createCarouselTemplate(altText, columns, options)]);
   }
 
+  /**
+   * @deprecated No longer recommended.
+   */
   sendImageCarouselTemplate(
     altText: string,
     columns: LineTypes.ImageCarouselColumnObject[],
     options: LineTypes.MessageOptions
   ) {
+    warning(
+      false,
+      '`context.sendImageCarouselTemplate()` is deprecated. Use `context.replyImageCarouselTemplate()` instead.'
+    );
     return this.send([
       Line.createImageCarouselTemplate(altText, columns, options),
     ]);

--- a/packages/bottender/src/line/__tests__/LineContext.spec.ts
+++ b/packages/bottender/src/line/__tests__/LineContext.spec.ts
@@ -1622,7 +1622,6 @@ describe('batch', () => {
         text: '6',
       },
     ]);
-    expect(warning).not.toBeCalled();
   });
 
   it('should not batch after handlerDidEnd has been called', async () => {


### PR DESCRIPTION
- context.useAccessToken
- context.replyButtonTemplate
- context.push
- context.pushText
- context.pushImage
- context.pushVideo
- context.pushAudio
- context.pushLocation
- context.pushSticker
- context.pushImagemap
- context.pushFlex
- context.pushTemplate
- context.pushButtonTemplate
- context.pushButtonsTemplate
- context.pushConfirmTemplate
- context.pushCarouselTemplate
- context.pushImageCarouselTemplate
- context.send
- context.sendImage
- context.sendVideo
- context.sendAudio
- context.sendLocation
- context.sendSticker
- context.sendImagemap
- context.sendFlex
- context.sendTemplate
- context.sendButtonTemplate
- context.sendButtonsTemplate
- context.sendConfirmTemplate
- context.sendCarouselTemplate
- context.sendImageCarouselTemplate
